### PR TITLE
chore: typo

### DIFF
--- a/packages/preset-uno/README.md
+++ b/packages/preset-uno/README.md
@@ -15,7 +15,7 @@ import presetUno from '@unocss/preset-uno'
 
 Unocss({
   presets: [
-    presetUno({ /* options */ })
+    presetUno()
   ]
 })
 ```


### PR DESCRIPTION
Passing parameters is not support