### PR TITLE
proposal(core): support onTrigger

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -9,13 +9,13 @@ export class UnoGenerator {
   private _cache = new Map<string, StringifiedUtil[] | null>()
   public config: ResolvedConfig
   public excluded = new Set<string>()
-  private onTrigger!: (
+  private onTrigger: (
     className: string,
     event: {
       type: Type,
       varients: any,
     }
-  ) => void
+  ) => void = () => {}
 
   constructor(
     public userConfig: UserConfig = {},


### PR DESCRIPTION
This is just a proposal. I just wrote a little to show my intention. 

In my plan, it is used to customize the hit or match of troubleshooting attributes.In Env mode, let users know how the set matching rules work in the generator

Do you think it is necessary to implement this function? If not, I'll give it up



