### PR TITLE
fix(playground): windows production build

### DIFF
--- a/playground/vite.config.ts
+++ b/playground/vite.config.ts
@@ -44,8 +44,8 @@ export default defineConfig({
         'fs',
       ],
       input: [
-        'index.html',
-        '__play.html',
+        resolve('./index.html'),
+        resolve('./__play.html'),
       ],
     },
   },


### PR DESCRIPTION
Resolved path's `\u` part was causing issue on Windows.

```
vite v2.6.13 building for production...
✓ 2 modules transformed.
[rollup-plugin-dynamic-import-variables] Bad character escape sequence (3:26)   
file: C:\Users\sib\dev\unocss\playground\__play.html:3:26
error during build:
SyntaxError: Bad character escape sequence (3:26)
    at Parser.pp$5.raise (C:\Users\sib\dev\unocss\node_modules\.pnpm\rollup@2.58.0\node_modules\rollup\dist\shared\rollup.js:19495:13)
```