### PR TITLE
feat: add flex-inline rule

### DIFF
--- a/packages/preset-uno/src/rules/flex.ts
+++ b/packages/preset-uno/src/rules/flex.ts
@@ -19,4 +19,5 @@ export const flex: Rule[] = [
   ['flex-shrink-0', { 'flex-shrink': 0 }],
   ['flex', { display: 'flex' }],
   ['inline-flex', { display: 'inline-flex' }],
+  ['flex-inline', { display: 'inline-flex' }],
 ]


### PR DESCRIPTION
I saw it on WindiCSS documentation. Useful for attributify mode:

```html
<div flex="inline col"></div>
```