### PR TITLE
fix(preset-uno): fix zIndex can't set negative number and 0

### DIFF
--- a/packages/preset-uno/src/utils/handlers/shorthand.ts
+++ b/packages/preset-uno/src/utils/handlers/shorthand.ts
@@ -19,7 +19,7 @@ const handler = function(
   this.__options.sequence = []
   for (const n of s) {
     const res = handlers[n](str)
-    if (res !== undefined)
+    if (res != null)
       return res
   }
   return undefined

--- a/packages/preset-uno/src/utils/handlers/shorthand.ts
+++ b/packages/preset-uno/src/utils/handlers/shorthand.ts
@@ -19,7 +19,7 @@ const handler = function(
   this.__options.sequence = []
   for (const n of s) {
     const res = handlers[n](str)
-    if (res)
+    if (res !== undefined)
       return res
   }
   return undefined

--- a/packages/preset-uno/src/variants/index.ts
+++ b/packages/preset-uno/src/variants/index.ts
@@ -35,7 +35,7 @@ export const variantNegative: Variant = {
         matcher: matcher.slice(1),
         body: (body) => {
           body.forEach((v) => {
-            v[1] = v[1]?.toString().replace(/[0-9.]+(?:[a-z]+|%)/, i => `-${i}`)
+            v[1] = v[1]?.toString().replace(/[0-9.]+(?:[a-z]+|%)?/, i => `-${i}`)
           })
           return body
         },

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -28,7 +28,7 @@ exports[`targets 1`] = `
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
 .mt-\\\\$height{margin-top:var(--height);}
 .next\\\\:mt-0+*{margin-top:0rem;}
-.-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
+.-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:-0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
 .space-x-\\\\$space>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
 .space-x-2>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
 .space-x-reverse>:not([hidden])~:not([hidden]){--un-space-x-reverse:1;}
@@ -245,6 +245,8 @@ exports[`targets 1`] = `
 .top-\\\\$top-height{top:var(--top-height);}
 .top-0{top:0rem;}
 .inset-x-5{left:1.25rem;right:1.25rem;}
+.-z-1{z-index:-1;}
+.z-0{z-index:0;}
 .z-1{z-index:1;}
 .z-100{z-index:100;}
 .box-border{box-sizing:border-box;}
@@ -281,9 +283,9 @@ exports[`targets 1`] = `
 .grayscale-90{--un-grayscale:grayscale(0.9);}
 .-backdrop-hue-rotate-90{--un-backdrop-hue-rotate:hue-rotate(-90deg);}
 .-hue-rotate-90{--un-hue-rotate:hue-rotate(-90deg);}
-.backdrop-hue-rotate-0{--un-backdrop-hue-rotate:hue-rotate(undefineddeg);}
+.backdrop-hue-rotate-0{--un-backdrop-hue-rotate:hue-rotate(0deg);}
 .backdrop-hue-rotate-360{--un-backdrop-hue-rotate:hue-rotate(360deg);}
-.hue-rotate-0{--un-hue-rotate:hue-rotate(undefineddeg);}
+.hue-rotate-0{--un-hue-rotate:hue-rotate(0deg);}
 .hue-rotate-360{--un-hue-rotate:hue-rotate(360deg);}
 .backdrop-invert{--un-backdrop-invert:invert(1);}
 .backdrop-invert-90{--un-backdrop-invert:invert(0.9);}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -176,6 +176,8 @@ const targets = [
   'transition-200',
   'transition',
   'w-1/2',
+  '-z-1',
+  'z-0',
   'z-1',
   'z-100',
   'box-content',


### PR DESCRIPTION
I find some problems. when i use default ruels about `zIndex`,  i can't use `z-0` and `-z-1`, and i think this is a bug. but now i resolve it.