### PR TITLE
fix(preset-uno): false positives on `tabSizes`

### DIFF
--- a/packages/preset-uno/src/rules/typography.ts
+++ b/packages/preset-uno/src/rules/typography.ts
@@ -1,4 +1,5 @@
 import { toArray, Rule } from '@unocss/core'
+import { isNumber } from '@vueuse/core'
 import { Theme } from '../theme'
 import { handler as h } from '../utils'
 
@@ -63,9 +64,10 @@ export const trackings: Rule<Theme>[] = [
   }],
 ]
 
+// https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size#values
 export const tabSizes: Rule<Theme>[] = [
-  [/^tab-?([^-]*)$/, ([, s]) => {
-    const v = h.bracket.number.rem(s) || 4
+  [/^tab-?(inherit|initial|revert|unset|([0-9]+(.*)?))$/, ([, t, s]) => {
+    const v = isNumber(s) ? (h.bracket.number.rem(s) || 4) : t
     return {
       '-moz-tab-size': v,
       '-o-tab-size': v,

--- a/packages/preset-uno/src/rules/typography.ts
+++ b/packages/preset-uno/src/rules/typography.ts
@@ -1,5 +1,4 @@
 import { toArray, Rule } from '@unocss/core'
-import { isNumber } from '@vueuse/core'
 import { Theme } from '../theme'
 import { handler as h } from '../utils'
 
@@ -66,13 +65,17 @@ export const trackings: Rule<Theme>[] = [
 
 // https://developer.mozilla.org/en-US/docs/Web/CSS/tab-size#values
 export const tabSizes: Rule<Theme>[] = [
-  [/^tab-?(inherit|initial|revert|unset|([0-9]+(.*)?))$/, ([, t, s]) => {
-    const v = isNumber(s) ? (h.bracket.number.rem(s) || 4) : t
-    return {
-      '-moz-tab-size': v,
-      '-o-tab-size': v,
-      'tab-size': v,
-    }
+  [/^tab-?(inherit|initial|revert|unset|(([0-9]+)(.*)?))$/, ([, cg, lg, ng]) => {
+    const v = typeof h.bracket.number(ng) !== 'undefined'
+      ? h.bracket.number.rem(lg)
+      : cg
+    return typeof v !== 'undefined'
+      ? {
+        '-moz-tab-size': v,
+        '-o-tab-size': v,
+        'tab-size': v,
+      }
+      : undefined
   }],
 ]
 

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -138,7 +138,9 @@ exports[`targets 1`] = `
 .text-4xl{font-size:2.25rem;line-height:2.5rem;}
 .text-base{font-size:1rem;line-height:1.5rem;}
 .text-lg{font-size:1.125rem;line-height:1.75rem;}
+.tab-1em{-moz-tab-size:1em;-o-tab-size:1em;tab-size:1em;}
 .tab-6{-moz-tab-size:6;-o-tab-size:6;tab-size:6;}
+.tab-unset{-moz-tab-size:unset;-o-tab-size:unset;tab-size:unset;}
 .indent{text-indent:1.5rem;}
 .indent-1\\\\/2{text-indent:50%;}
 .indent-lg{text-indent:2rem;}

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -35,6 +35,7 @@ exports[`targets 1`] = `
 .grid-cols-\\\\$1{grid-template-columns:var(--1);}
 .items-\\\\$size{align-items:var(--size);}
 .object-\\\\$fit{object-fit:var(--fit);}
+.tab-\\\\$tabprop{tab-size:var(--tabprop);}
 .\\\\!p-5px{padding:5px !important;}
 .group:focus .group-focus\\\\:p-4{padding:1rem;}
 .hover\\\\:\\\\!p-1:hover{padding:0.25rem !important;}
@@ -137,7 +138,6 @@ exports[`targets 1`] = `
 .text-4xl{font-size:2.25rem;line-height:2.5rem;}
 .text-base{font-size:1rem;line-height:1.5rem;}
 .text-lg{font-size:1.125rem;line-height:1.75rem;}
-.tab,.tab-\\\\$tabprop{-moz-tab-size:4;-o-tab-size:4;tab-size:4;}
 .tab-6{-moz-tab-size:6;-o-tab-size:6;tab-size:6;}
 .indent{text-indent:1.5rem;}
 .indent-1\\\\/2{text-indent:50%;}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -238,6 +238,8 @@ const targets = [
   'hyphens-none',
   'tab',
   'tab-6',
+  'tab-1em',
+  'tab-unset',
   'indent',
   'indent-1/2',
   'indent-lg',


### PR DESCRIPTION
We need to review `typography` module, all functions using `rem` handler seems to be too generic.

closes #156 
