### PR TITLE
feat(preset-attributify): support attributes that end with %

### DIFF
--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -8,7 +8,7 @@ const strippedPrefixes = [
 
 const splitterRE = /[\s'"`;]+/g
 const elementRE = /<\w[\w:\.$-]*\s((?:'[\s\S]*?'|"[\s\S]*?"|`[\s\S]*?`|\{[\s\S]*?\}|[\s\S]*?)*?)>/g
-const valuedAttributeRE = /([?]|[\w:-]+)(?:=(["'])([^\2]+?)\2)?/g
+const valuedAttributeRE = /([?]|[\w:%-]+)(?:=(["'])([^\2]+?)\2)?/g
 
 export const extractorAttributify = (options?: AttributifyOptions): Extractor => ({
   name: 'attributify',

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -32,6 +32,10 @@ Set {
   "[ma=\\"\\"]",
   "[rounded-sm=\\"\\"]",
   "[inline-block=\\"\\"]",
+  "[transform=\\"\\"]",
+  "[translate-x-100%=\\"\\"]",
+  "[translate-y-=\\"\\"]",
+  "[rotate-30=\\"\\"]",
 }
 `;
 
@@ -81,7 +85,10 @@ exports[`attributify fixture1 1`] = `
 [flex~=\\"col\\"]{flex-direction:column;}
 [flex~=\\"\\\\~\\"]{display:flex;}
 .absolute{position:absolute;}
-.fixed{position:fixed;}"
+.fixed{position:fixed;}
+[transform=\\"\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+[translate-x-100\\\\%=\\"\\"]{--un-translate-x:100%;}
+[rotate-30=\\"\\"]{--un-rotate:30deg;}"
 `;
 
 exports[`attributify fixture2 1`] = `
@@ -139,5 +146,9 @@ Array [
   "ma",
   "rounded-sm",
   "inline-block",
+  "transform",
+  "translate-x-100%",
+  "translate-y-",
+  "rotate-30",
 ]
 `;

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -18,6 +18,10 @@ describe('attributify', () => {
   un-children="m-auto"
   pt2 ma rounded-sm
   inline-block
+  transform
+  translate-x-100%
+  translate-y-[10%]
+  rotate-30
 >
   Button
 </button>


### PR DESCRIPTION
I changed the regex in `extractor.ts` to support attributes that end with: `%`. 

All tests passed both before and after I updated the snapshot.

I also tested against the default unocss playground, my own html files that I use to test my own custom rules and validated the regex on regex101.com.