### PR TITLE
feat: Support font family customization and font compression configuration

### DIFF
--- a/packages/preset-font/package.json
+++ b/packages/preset-font/package.json
@@ -1,0 +1,57 @@
+{
+  "name": "@unocss/preset-font",
+  "version": "0.12.13",
+  "description": "Pure CSS font for UnoCSS",
+  "keywords": [
+    "unocss",
+    "unocss-preset",
+    "font",
+    "css-font",
+    "iconify"
+  ],
+  "homepage": "https://github.com/antfu/unocss/tree/main/packages/preset-font#readme",
+  "bugs": {
+    "url": "https://github.com/antfu/unocss/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/antfu/unocss.git",
+    "directory": "packages/preset-font"
+  },
+  "funding": "https://github.com/sponsors/antfu",
+  "license": "MIT",
+  "author": "Anthony Fu <anthonyfu117@hotmail.com>",
+  "sideEffects": false,
+  "exports": {
+    ".": {
+      "require": "./dist/index.js",
+      "import": "./dist/index.mjs",
+      "types": "./dist/index.d.ts"
+    },
+    "./fs": {
+      "require": "./dist/fs.js",
+      "import": "./dist/fs.mjs",
+      "types": "./dist/fs.d.ts"
+    }
+  },
+  "main": "dist/index.js",
+  "module": "dist/index.mjs",
+  "types": "dist/index.d.ts",
+  "files": [
+    "dist",
+    "*.css"
+  ],
+  "scripts": {
+    "build": "tsup",
+    "dev": "tsup --watch src"
+  },
+  "dependencies": {
+    "@iconify/utils": "^1.0.19",
+    "@unocss/core": "workspace:*",
+    "fontmin": "^0.9.9",
+    "local-pkg": "^0.4.0"
+  },
+  "devDependencies": {
+    "@iconify/types": "^1.0.12"
+  }
+}

--- a/packages/preset-font/src/index.ts
+++ b/packages/preset-font/src/index.ts
@@ -1,0 +1,61 @@
+import { CSSObject, Preset, Rule, StaticRule, warnOnce } from '@unocss/core';
+import { iconToSVG } from '@iconify/utils/lib/svg/build';
+import { defaults as DefaultIconCustomizations } from '@iconify/utils/lib/customisations';
+import { getIconData } from '@iconify/utils/lib/icon-set/get-icon';
+/* eslint-disable @typescript-eslint/no-var-requires */
+import Fontmin from 'fontmin'
+
+
+const fontmin = new Fontmin()
+    .src('src/fonts/FZDWTJW.ttf')
+    .use(Fontmin.glyph({
+        text: words,
+    }))
+    .use(Fontmin.ttf2woff())
+    .dest('src/assets/fonts');
+
+// fontmin.run(err => {
+//     if (err) {
+//         throw err;
+//     }
+// });
+
+type fontType = 'woff' | 'truetype' | 'svg' | 'woff2' | 'embedded-opentype' | 'eot'; // font type in css property
+type PresetFontParams = {
+    entries: {
+        text: string, // texts include in `src`
+        src: string, // file source
+        dest: string, // output dist
+        fontType?: fontType[],
+        family: string, // font-family
+        extraProperties: CSSObject;
+    }[];
+    layer?: string; //  = 'font-family'
+    extraProperties: Record<string, unknown>;
+};
+
+export const preset = (params: PresetFontParams): Preset => {
+    const {
+        entries,
+    } = params;
+    const fontRules = entries.map(entry => {
+        const fontType = entry.fontType || ['woff'];
+        const fontFace = {
+            '@font-face': `{'font-family': ${ entry.family };src: url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.eot');
+                src: url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.eot?#iefix') format('embedded-opentype'),
+                    url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.woff2') format('woff2'),
+                    url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.woff') format('woff'),
+                    url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.ttf') format('truetype'),
+                    url('//at.alicdn.com/t/font_1258536_pkwzne0lvt.svg#iconfont') format('svg');
+            }`
+        };
+        return [entry.family, { 'S': 'S', ...entry.extraProperties }] as Rule;
+    });
+    return {
+        name: '@unocss/font',
+        enforce: 'pre',
+        rules: fontRules
+    };
+};
+
+export default preset;


### PR DESCRIPTION
This is a proposal, I think of an idea

input:
```
src:https://tx2.a.kwimgs.com/udata/pkg/AUTO-KUAISHOU-COM-STATIC-FONT/DINCondensed.ttf
dest: '/build/fonts'
family: 'din1451'
text: '新年快乐'
```

usage
```<div class=" font-din1451"> 快乐 </div>```


If you agree with me, I will continue @antfu @userquin 


