### PR TITLE
feat(preset-uno + preset-icons): extract and update regexes

### DIFF
--- a/packages/preset-icons/src/utils.ts
+++ b/packages/preset-icons/src/utils.ts
@@ -1,6 +1,6 @@
 export const isNode = typeof process < 'u' && typeof process.stdout < 'u'
 
-const svgCharRe = [
+const svgCharRe: [RegExp, string][] = [
     [/"/g, '\''],
     [/%/g, '%25'],
     [/#/g, '%23'],
@@ -9,6 +9,7 @@ const svgCharRe = [
     [/</g, '%3C'],
     [/>/g, '%3E'],
 ]
+
 // https://bl.ocks.org/jennyknuth/222825e315d45a738ed9d6e04c7a88d0
 export function encodeSvg(svg: string) {
   return svgCharRe.reduce(

--- a/packages/preset-icons/src/utils.ts
+++ b/packages/preset-icons/src/utils.ts
@@ -1,19 +1,13 @@
 export const isNode = typeof process < 'u' && typeof process.stdout < 'u'
 
-const svgCharRe: [RegExp, string][] = [
-    [/"/g, '\''],
-    [/%/g, '%25'],
-    [/#/g, '%23'],
-    [/{/g, '%7B'],
-    [/}/g, '%7D'],
-    [/</g, '%3C'],
-    [/>/g, '%3E'],
-]
-
 // https://bl.ocks.org/jennyknuth/222825e315d45a738ed9d6e04c7a88d0
 export function encodeSvg(svg: string) {
-  return svgCharRe.reduce(
-    (str, [regexp, replacement]) => str.replace(regexp, replacement),
-    svg.replace('<svg', (~svg.indexOf('xmlns') ? '<svg' : '<svg xmlns="http://www.w3.org/2000/svg"'))
-  )
+  return svg.replace('<svg', (~svg.indexOf('xmlns') ? '<svg' : '<svg xmlns="http://www.w3.org/2000/svg"'))
+    .replace(/"/g, '\'')
+    .replace(/%/g, '%25')
+    .replace(/#/g, '%23')
+    .replace(/{/g, '%7B')
+    .replace(/}/g, '%7D')
+    .replace(/</g, '%3C')
+    .replace(/>/g, '%3E')
 }

--- a/packages/preset-icons/src/utils.ts
+++ b/packages/preset-icons/src/utils.ts
@@ -1,13 +1,18 @@
 export const isNode = typeof process < 'u' && typeof process.stdout < 'u'
 
+const svgCharRe = [
+    [/"/g, '\''],
+    [/%/g, '%25'],
+    [/#/g, '%23'],
+    [/{/g, '%7B'],
+    [/}/g, '%7D'],
+    [/</g, '%3C'],
+    [/>/g, '%3E'],
+]
 // https://bl.ocks.org/jennyknuth/222825e315d45a738ed9d6e04c7a88d0
 export function encodeSvg(svg: string) {
-  return svg.replace('<svg', (~svg.indexOf('xmlns') ? '<svg' : '<svg xmlns="http://www.w3.org/2000/svg"'))
-    .replace(/"/g, '\'')
-    .replace(/%/g, '%25')
-    .replace(/#/g, '%23')
-    .replace(/{/g, '%7B')
-    .replace(/}/g, '%7D')
-    .replace(/</g, '%3C')
-    .replace(/>/g, '%3E')
+  return svgCharRe.reduce(
+    (str, [regexp, replacement]) => str.replace(regexp, replacement),
+    svg.replace('<svg', (~svg.indexOf('xmlns') ? '<svg' : '<svg xmlns="http://www.w3.org/2000/svg"'))
+  )
 }

--- a/packages/preset-uno/src/rules/animation.ts
+++ b/packages/preset-uno/src/rules/animation.ts
@@ -149,6 +149,8 @@ const properties: Record<string, object> = {
   'zoom-out-up': { 'transform-origin': 'center bottom' },
 }
 
+const animationDurationRe = /-duration/
+const animationIterationCountRe = /-/g
 export const animations: Rule[] = [
   [/^animate-(.*)$/, ([, name], { constructCSS }) => {
     const kf = keyframes[name]
@@ -158,11 +160,11 @@ export const animations: Rule[] = [
     }
   }],
   ['animate-none', { animation: 'none' }],
-  [/^animate(?:-duration)?-((.+)(?:(s|ms)?))$/, ([, d]) => ({ 'animation-duration': h.bracket.time(d.replace(/-duration/, '')) })],
+  [/^animate(?:-duration)?-((.+)(?:(s|ms)?))$/, ([, d]) => ({ 'animation-duration': h.bracket.time(d.replace(animationDurationRe, '')) })],
   [/^animate-delay-((.+)(?:(s|ms)?))$/, ([, d]) => ({ 'animation-delay': h.bracket.time(d) })],
   [/^animate-(?:fill-)?mode-(none|forwards|backwards|both|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-fill-mode': d })],
   [/^animate-(?:direction-)?(normal|reverse|alternate|alternate-reverse|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-direction': d })],
-  [/^animate-(?:iteration-)?count-(.+)$/, ([, d]) => ({ 'animation-iteration-count': d.replace(/\-/g, ', ') })],
+  [/^animate-(?:iteration-)?count-(.+)$/, ([, d]) => ({ 'animation-iteration-count': d.replace(animationIterationCountRe, ', ') })],
   [/^animate-name-(.+)/, ([, d]) => ({ 'animation-name': d })],
   [/^animate-play(?:-state)?-(paused|running|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-play-state': d })],
 ]

--- a/packages/preset-uno/src/rules/behaviors.ts
+++ b/packages/preset-uno/src/rules/behaviors.ts
@@ -49,10 +49,13 @@ export const outline: Rule[] = [
   ],
 ]
 
+const listStyleRe1 = /-inside|-outside/
+const listStyleRe2 = /inside|outside/
+
 export const listStyle: Rule[] = [
-  [new RegExp(`^list-((${listStyleProps.join('|')})(?:(-outside|-inside))?)$`), ([, value]) => {
-    const style = value.split(/-outside|-inside/)[0]
-    const position = /inside|outside/.exec(value) ?? []
+  [new RegExp(`^list-((${listStyleProps.join('|')})(?:(-inside|-outside))?)$`), ([, value]) => {
+    const style = value.split(listStyleRe1)[0]
+    const position = listStyleRe2.exec(value) ?? []
 
     if (position.length) {
       return {

--- a/packages/preset-uno/src/utils/handlers/handlers.ts
+++ b/packages/preset-uno/src/utils/handlers/handlers.ts
@@ -67,7 +67,7 @@ export function cssvar(str: string) {
     return `var(--${str.slice(1)})`
 }
 
-const timeRe = /(s|ms)$/
+const timeRe = /(ms|s)$/
 export function time(str: string) {
   const duration = Number(str.replace(timeRe, ''))
 

--- a/packages/preset-uno/src/utils/handlers/handlers.ts
+++ b/packages/preset-uno/src/utils/handlers/handlers.ts
@@ -67,13 +67,14 @@ export function cssvar(str: string) {
     return `var(--${str.slice(1)})`
 }
 
+const timeRe = /(s|ms)$/
 export function time(str: string) {
-  const duration = Number(str.replace(/(s|ms)$/, ''))
+  const duration = Number(str.replace(timeRe, ''))
 
   if (isNaN(duration))
     return
 
-  if (/ms|s$/.test(str))
+  if (timeRe.test(str))
     return str
 
   return `${str}ms`


### PR DESCRIPTION
Compared to #182, this PR targets part of the code base that requires some logic update. To note:
- `encodeSvg()`: extract to array and use reduce.
- `time()`: changed the second regex (`/ms|s$/`) to match the first one (`/(s|ms)$/`)
