### PR TITLE
feat(preset-uno): add peer variant support

### DIFF
--- a/packages/preset-uno/src/variants/pseudo.ts
+++ b/packages/preset-uno/src/variants/pseudo.ts
@@ -49,6 +49,7 @@ const PseudoClassesStr = Object.keys(PseudoClasses).join('|')
 const PseudoClassesRE = new RegExp(`^(${PseudoClassesStr})[:-]`)
 const PseudoClassesNotRE = new RegExp(`^not-(${PseudoClassesStr})[:-]`)
 const PseudoClassesGroupRE = new RegExp(`^group-(${PseudoClassesStr})[:-]`)
+const PseudoClassesPeerRE = new RegExp(`^peer-(${PseudoClassesStr})[:-]`)
 
 export const variantPseudoElements: VariantFunction = (input: string) => {
   const match = input.match(PseudoElementsRE)
@@ -88,6 +89,17 @@ export const variantPseudoClasses: VariantObject = {
         selector: s => s.includes('.group:')
           ? s.replace(/\.group:/, `.group:${pseudo}:`)
           : `.group:${pseudo} ${s}`,
+      }
+    }
+
+    match = input.match(PseudoClassesPeerRE)
+    if (match) {
+      const pseudo = PseudoClasses[match[1]] || match[1]
+      return {
+        matcher: input.slice(match[1].length + 6),
+        selector: s => s.includes('.peer:')
+          ? s.replace(/\.peer:/, `.peer:${pseudo}:`)
+          : `.peer:${pseudo} ~ ${s}`,
       }
     }
   },

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -88,6 +88,7 @@ exports[`targets 1`] = `
 .bg-teal-400\\\\/\\\\[\\\\.55\\\\]{background-color:rgba(45,212,191,0.55);}
 .bg-teal-500\\\\/\\\\[55\\\\%\\\\]{background-color:rgba(20,184,166,55%);}
 .hover\\\\:not-first\\\\:checked\\\\:bg-red\\\\/10:hover:not(:first-child):checked{background-color:rgba(248,113,113,0.1);}
+.peer:checked ~ .peer-checked\\\\:bg-blue-500{--un-bg-opacity:1;background-color:rgba(59,130,246,var(--un-bg-opacity));}
 .bg-opacity-45{--un-bg-opacity:0.45;}
 .from-current{--un-gradient-from:currentColor;--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .from-green-500{--un-gradient-from:rgba(34,197,94, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
@@ -166,7 +167,6 @@ exports[`targets 1`] = `
 .text-shadow-lg{text-shadow:3px 3px 6px rgb(0 0 0 / 26%), 0 0 5px rgb(15 3 86 / 22%);}
 .text-shadow-none{text-shadow:none;}
 .group:focus:hover .group-hover\\\\:group-focus\\\\:text-center{text-align:center;}
-.peer:checked ~ .peer-checked\\\\:bg-blue-500{--un-bg-opacity:1;background-color:rgba(59,130,246,var(--un-bg-opacity));}
 .text-\\\\[\\\\#124\\\\]{--un-text-opacity:1;color:rgba(17,34,68,var(--un-text-opacity));}
 .text-black\\\\/10{color:rgba(0,0,0,0.1);}
 .text-blue{--un-text-opacity:1;color:rgba(96,165,250,var(--un-text-opacity));}

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -166,6 +166,7 @@ exports[`targets 1`] = `
 .text-shadow-lg{text-shadow:3px 3px 6px rgb(0 0 0 / 26%), 0 0 5px rgb(15 3 86 / 22%);}
 .text-shadow-none{text-shadow:none;}
 .group:focus:hover .group-hover\\\\:group-focus\\\\:text-center{text-align:center;}
+.peer:checked ~ .peer-checked\\\\:bg-blue-500{--un-bg-opacity:1;background-color:rgba(59,130,246,var(--un-bg-opacity));}
 .text-\\\\[\\\\#124\\\\]{--un-text-opacity:1;color:rgba(17,34,68,var(--un-text-opacity));}
 .text-black\\\\/10{color:rgba(0,0,0,0.1);}
 .text-blue{--un-text-opacity:1;color:rgba(96,165,250,var(--un-text-opacity));}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -105,6 +105,7 @@ const targets = [
   'not-hover:p-3',
   'group-focus:p-4',
   'group-hover:group-focus:text-center',
+  'peer-checked:bg-blue-500',
   'hover:not-first:checked:bg-red/10',
   'hover:p-5',
   'leading-2',


### PR DESCRIPTION
I want to add `.peer` support (see [tailwind's doc](https://tailwindcss.com/docs/just-in-time-mode#sibling-selector-variants) and [source](https://github.com/tailwindlabs/tailwindcss/blob/v3.0.0-alpha.2/src/corePlugins.js#L108)). However I couldn't figure out how to add the test, so the code is only based on copy-paste from the `Group` section.