### PR TITLE
feat: allow a rule to return multiple css items, close #197

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,6 +1,6 @@
-import { UserConfig, ParsedUtil, StringifiedUtil, UserConfigDefaults, VariantMatchedResult, Variant, ResolvedConfig, CSSEntries, GenerateResult, CSSObject, RawUtil, ExtractorContext, GenerateOptions, RuleContext, RuleMeta, VariantHandler } from '../types'
+import { UserConfig, ParsedUtil, StringifiedUtil, UserConfigDefaults, VariantMatchedResult, Variant, ResolvedConfig, CSSEntries, GenerateResult, CSSObject, RawUtil, ExtractorContext, GenerateOptions, RuleContext, RuleMeta, VariantHandler, CSSValues } from '../types'
 import { resolveConfig } from '../config'
-import { e, entriesToCss, expandVariantGroup, isRawUtil, isStaticShortcut, TwoKeyMap, uniq, warnOnce } from '../utils'
+import { e, entriesToCss, expandVariantGroup, isRawUtil, isStaticShortcut, notNull, TwoKeyMap, uniq, warnOnce } from '../utils'
 import { version } from '../../package.json'
 
 export class UnoGenerator {
@@ -128,9 +128,9 @@ export class UnoGenerator {
       }
       // no shortcut
       else {
-        const util = this.stringifyUtil(await this.parseUtil(applied, context))
-        if (util)
-          return hit(raw, [util])
+        const utils = (await this.parseUtil(applied, context))?.map(i => this.stringifyUtil(i)).filter(notNull)
+        if (utils?.length)
+          return hit(raw, utils)
       }
 
       // set null cache for unmatched result
@@ -272,7 +272,7 @@ export class UnoGenerator {
   }
 
   constructCustomCSS(context: Readonly<RuleContext>, body: CSSObject | CSSEntries, overrideSelector?: string) {
-    body = normalizeEntries(body)
+    body = normalizeCSSEntries(body)
 
     const [selector, entries, mediaQuery] = this.applyVariants([0, overrideSelector || context.rawSelector, body, undefined, context.variantHandlers])
     const cssBody = `${selector}{${entriesToCss(entries)}}`
@@ -281,7 +281,7 @@ export class UnoGenerator {
     return cssBody
   }
 
-  async parseUtil(input: string | VariantMatchedResult, context: RuleContext, internal = false): Promise<ParsedUtil | RawUtil | undefined> {
+  async parseUtil(input: string | VariantMatchedResult, context: RuleContext, internal = false): Promise<ParsedUtil[] | RawUtil[] | undefined> {
     const [raw, processed, variantHandlers] = typeof input === 'string'
       ? this.matchVariants(input)
       : input
@@ -290,7 +290,7 @@ export class UnoGenerator {
     const staticMatch = this.config.rulesStaticMap[processed]
     if (staticMatch) {
       if (staticMatch[1] && (internal || !staticMatch[2]?.internal))
-        return [staticMatch[0], raw, normalizeEntries(staticMatch[1]), staticMatch[2], variantHandlers]
+        return [[staticMatch[0], raw, normalizeCSSEntries(staticMatch[1]), staticMatch[2], variantHandlers]]
     }
 
     context.variantHandlers = variantHandlers
@@ -320,10 +320,10 @@ export class UnoGenerator {
         continue
 
       if (typeof result === 'string')
-        return [i, result, meta]
-      const entries = normalizeEntries(result).filter(i => i[1] != null)
+        return [[i, result, meta]]
+      const entries = normalizeCSSValues(result).filter(i => i.length)
       if (entries.length)
-        return [i, raw, entries, meta, variantHandlers]
+        return entries.map(e => [i, raw, e, meta, variantHandlers])
     }
   }
 
@@ -394,8 +394,9 @@ export class UnoGenerator {
           const result = await this.parseUtil(i, context, true)
           if (!result)
             warnOnce(`unmatched utility "${i}" in shortcut "${parent[1]}"`)
-          return result as ParsedUtil
+          return (result || []) as ParsedUtil[]
         })))
+      .flat(1)
       .filter(Boolean)
       .sort((a, b) => a[0] - b[0])
 
@@ -452,6 +453,19 @@ function toEscapedSelector(raw: string) {
     return `.${e(raw)}`
 }
 
-function normalizeEntries(obj: CSSObject | CSSEntries) {
-  return !Array.isArray(obj) ? Object.entries(obj) : obj
+export function normalizeCSSEntries(obj: CSSEntries | CSSObject): CSSEntries {
+  return (!Array.isArray(obj) ? Object.entries(obj) : obj).filter(i => i[1] != null)
+}
+
+export function normalizeCSSValues(obj: CSSValues): CSSEntries[] {
+  if (Array.isArray(obj)) {
+    // @ts-expect-error
+    if (obj.find(i => !Array.isArray(i) || Array.isArray(i[0])))
+      return (obj as any).map((i: any) => normalizeCSSEntries(i))
+    else
+      return [obj as any]
+  }
+  else {
+    return [normalizeCSSEntries(obj)]
+  }
 }

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -165,14 +165,14 @@ export class UnoGenerator {
           if (!sorted.length)
             return undefined
           const rules = sorted
+            .reverse()
             .map(([selector, body], idx) => {
               if (selector && this.config.mergeSelectors) {
                 // search for rules that has exact same body, and merge them
-                // the index is reversed to make sure we always merge to the last one
-                for (let i = size - 1; i > idx; i--) {
+                for (let i = idx + 1; i < size; i++) {
                   const current = sorted[i]
                   if (current && current[0] && current[1] === body) {
-                    current[0] = `${selector},${current[0]}`
+                    current[0] = `${current[0]},${selector}`
                     return null
                   }
                 }
@@ -182,6 +182,7 @@ export class UnoGenerator {
                 : body
             })
             .filter(Boolean)
+            .reverse()
             .join(nl)
 
           return parent

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -67,7 +67,9 @@ export interface RuleMeta {
   internal?: boolean
 }
 
-export type DynamicMatcher<Theme extends {} = {}> = ((match: string[], context: Readonly<RuleContext<Theme>>) => Awaitable<CSSObject | CSSEntries | string | undefined>)
+export type CSSValues = CSSObject | CSSEntries | (CSSObject | CSSEntries)[]
+
+export type DynamicMatcher<Theme extends {} = {}> = ((match: string[], context: Readonly<RuleContext<Theme>>) => Awaitable<CSSValues | string | undefined>)
 export type DynamicRule<Theme extends {} = {}> = [RegExp, DynamicMatcher<Theme>] | [RegExp, DynamicMatcher<Theme>, RuleMeta]
 export type StaticRule = [string, CSSObject | CSSEntries] | [string, CSSObject | CSSEntries, RuleMeta]
 export type Rule<Theme extends {} = {}> = DynamicRule<Theme> | StaticRule

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -20,3 +20,7 @@ export function normalizeVariant(variant: Variant): VariantObject {
 export function isRawUtil(util: ParsedUtil | RawUtil | StringifiedUtil): util is RawUtil {
   return util.length === 3
 }
+
+export function notNull<T>(value: T | null | undefined): value is T {
+  return value != null
+}

--- a/packages/preset-uno/src/rules/transform.ts
+++ b/packages/preset-uno/src/rules/transform.ts
@@ -1,24 +1,22 @@
-import { Rule, CSSEntries, CSSObject } from '@unocss/core'
+import { Rule, CSSValues } from '@unocss/core'
 import { xyzMap, handler as h } from '../utils'
 
+const transformBase = {
+  '--un-rotate': 0,
+  '--un-scale-x': 1,
+  '--un-scale-y': 1,
+  '--un-scale-z': 1,
+  '--un-skew-x': 0,
+  '--un-skew-y': 0,
+  '--un-translate-x': 0,
+  '--un-translate-y': 0,
+  '--un-translate-z': 0,
+  'transform': 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z))',
+}
+
 export const transforms: Rule[] = [
-  [
-    'transform', {
-      '--un-rotate': 0,
-      '--un-scale-x': 1,
-      '--un-scale-y': 1,
-      '--un-scale-z': 1,
-      '--un-skew-x': 0,
-      '--un-skew-y': 0,
-      '--un-translate-x': 0,
-      '--un-translate-y': 0,
-      '--un-translate-z': 0,
-      'transform': 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z))',
-    },
-  ],
-  [/^preserve-(3d|flat)$/, ([, value]) => ({
-    'transform-style': value === '3d' ? `preserve-${value}` : value,
-  })],
+  ['transform', transformBase],
+  [/^preserve-(3d|flat)$/, ([, value]) => ({ 'transform-style': value === '3d' ? `preserve-${value}` : value })],
   [/^translate()-([^-]+)$/, handleTranslate],
   [/^translate-([xyz])-([^-]+)$/, handleTranslate],
   [/^scale()-([^-]+)$/, handleScale],
@@ -35,26 +33,36 @@ export const transforms: Rule[] = [
   ['origin-top-left', { 'transform-origin': 'top left' }],
 ]
 
-function handleTranslate([, d, b]: string[]): CSSEntries | undefined {
+function handleTranslate([, d, b]: string[]): CSSValues | undefined {
   const v = h.bracket.fraction.rem(b)
   if (v != null) {
     return [
-      ...xyzMap[d].map((i): [string, string] => [`--un-translate${i}`, v]),
+      transformBase,
+      [
+        ...xyzMap[d].map((i): [string, string] => [`--un-translate${i}`, v]),
+      ],
     ]
   }
 }
 
-function handleScale([, d, b]: string[]): CSSEntries | undefined {
+function handleScale([, d, b]: string[]): CSSValues | undefined {
   const v = h.bracket.fraction.percent(b)
   if (v != null) {
     return [
-      ...xyzMap[d].map((i): [string, string] => [`--un-scale${i}`, v]),
+      transformBase,
+      [
+        ...xyzMap[d].map((i): [string, string] => [`--un-scale${i}`, v]),
+      ],
     ]
   }
 }
 
-function handleRotate([, b]: string[]): CSSObject | undefined {
+function handleRotate([, b]: string[]): CSSValues | undefined {
   const v = h.bracket.number(b)
-  if (v != null)
-    return { '--un-rotate': `${v}deg` }
+  if (v != null) {
+    return [
+      transformBase,
+      { '--un-rotate': `${v}deg` },
+    ]
+  }
 }

--- a/packages/preset-uno/src/variants/misc.ts
+++ b/packages/preset-uno/src/variants/misc.ts
@@ -25,6 +25,8 @@ export const variantNegative: Variant = {
         matcher: matcher.slice(1),
         body: (body) => {
           body.forEach((v) => {
+            if (v[0].startsWith('--un-scale') || v[1]?.toString() === '0')
+              return
             v[1] = v[1]?.toString().replace(/[0-9.]+(?:[a-z]+|%)?/, i => `-${i}`)
           })
           return body

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -66,7 +66,7 @@ exports[`attributify fixture1 1`] = `
 "/* layer: default */
 [p~=\\"x-4\\"]{padding-left:1rem;padding-right:1rem;}
 [p~=\\"y-2\\"]{padding-top:0.5rem;padding-bottom:0.5rem;}
-[pt~=\\"\\\\32 \\"],[p~=\\"t-2\\"],[pt2=\\"\\"]{padding-top:0.5rem;}
+[p~=\\"t-2\\"],[pt~=\\"\\\\32 \\"],[pt2=\\"\\"]{padding-top:0.5rem;}
 [ma=\\"\\"],[un-children~=\\"m-auto\\"] > *{margin:auto;}
 [inline-block=\\"\\"]{display:inline-block;}
 .dark [bg~=\\"dark\\\\:\\\\!blue-500\\"]{--un-bg-opacity:1 !important;background-color:rgba(59,130,246,var(--un-bg-opacity)) !important;}
@@ -86,7 +86,7 @@ exports[`attributify fixture1 1`] = `
 [flex~=\\"\\\\~\\"]{display:flex;}
 .absolute{position:absolute;}
 .fixed{position:fixed;}
-[transform=\\"\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+[transform=\\"\\"],[translate-x-100\\\\%=\\"\\"],[rotate-30=\\"\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 [translate-x-100\\\\%=\\"\\"]{--un-translate-x:100%;}
 [rotate-30=\\"\\"]{--un-rotate:30deg;}"
 `;

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -55,7 +55,7 @@ exports[`targets 1`] = `
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
 .mt-\\\\$height{margin-top:var(--height);}
 .next\\\\:mt-0+*{margin-top:0rem;}
-.-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:-0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
+.-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
 .space-x-\\\\$space>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
 .space-x-2>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
 .space-x-reverse>:not([hidden])~:not([hidden]){--un-space-x-reverse:1;}
@@ -378,9 +378,8 @@ exports[`targets 1`] = `
 .table-row-group{display:table-row-group;}
 .preserve-3d{transform-style:preserve-3d;}
 .preserve-flat{transform-style:flat;}
-.-translate-full,.-translate-x-full,.-translate-y-1\\\\/2{--un-rotate:-0;--un-scale-x:-1;--un-scale-y:-1;--un-scale-z:-1;--un-skew-x:-0;--un-skew-y:-0;--un-translate-x:-0;--un-translate-y:-0;--un-translate-z:-0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+.-translate-full,.translate-full,.-translate-x-full,.-translate-y-1\\\\/2,.translate-x-full,.translate-y-1\\\\/4{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;}
-.translate-full,.translate-x-full,.translate-y-1\\\\/4{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .translate-full{--un-translate-x:100%;--un-translate-y:100%;}
 .-translate-x-full{--un-translate-x:-100%;}
 .-translate-y-1\\\\/2{--un-translate-y:-50%;}

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -10,13 +10,13 @@ exports[`containers 1`] = `
 .container,.md\\\\:container{max-width:768px;}
 }
 @media (min-width: 1024px){
-.lg\\\\:container,.container,.md\\\\:container{max-width:1024px;}
+.container,.lg\\\\:container,.md\\\\:container{max-width:1024px;}
 }
 @media (min-width: 1280px){
-.lg\\\\:container,.container,.md\\\\:container{max-width:1280px;}
+.container,.lg\\\\:container,.md\\\\:container{max-width:1280px;}
 }
 @media (min-width: 1536px){
-.lg\\\\:container,.container,.md\\\\:container{max-width:1536px;}
+.container,.lg\\\\:container,.md\\\\:container{max-width:1536px;}
 }"
 `;
 
@@ -37,20 +37,20 @@ exports[`targets 1`] = `
 .object-\\\\$fit{object-fit:var(--fit);}
 .tab-\\\\$tabprop{tab-size:var(--tabprop);}
 .\\\\!p-5px{padding:5px !important;}
+.first\\\\:p-2:first-child,.p-2,.p2{padding:0.5rem;}
 .group:focus .group-focus\\\\:p-4{padding:1rem;}
 .hover\\\\:\\\\!p-1:hover{padding:0.25rem !important;}
 .hover\\\\:p-5:hover{padding:1.25rem;}
 .not-hover\\\\:p-3:not(:hover){padding:0.75rem;}
-.p-2,.first\\\\:p-2:first-child,.p2{padding:0.5rem;}
 .\\\\!hover\\\\:px-10:hover{padding-left:2.5rem !important;padding-right:2.5rem !important;}
+.p-t-2,.pt-2,.pt2{padding-top:0.5rem;}
 .pl-10px{padding-left:10px;}
 .pt-\\\\$title2{padding-top:var(--title2);}
-.pt-2,.p-t-2,.pt2{padding-top:0.5rem;}
+.-m-auto,.all\\\\:m-auto *,.children\\\\:m-auto > *,.m-auto{margin:auto;}
 .\\\\!m-\\\\$c-m{margin:var(--c-m) !important;}
 .m-\\\\[3em\\\\]{margin:3em;}
 .m-0{margin:0rem;}
 .m-1\\\\/2{margin:50%;}
-.children\\\\:m-auto > *,.all\\\\:m-auto *,.-m-auto,.m-auto{margin:auto;}
 .my-auto{margin-top:auto;margin-bottom:auto;}
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
 .mt-\\\\$height{margin-top:var(--height);}
@@ -77,10 +77,10 @@ exports[`targets 1`] = `
 .bg-blend-luminosity{background-blend-mode:luminosity;}
 .bg-clip-border{-webkit-background-clip:border-box;background-attachment:border-box;}
 .bg-clip-text{-webkit-background-clip:text;background-attachment:text;}
-.bg-\\\\[\\\\#1533\\\\]{background-color:rgba(17,85,51,0.2);}
 .bg-\\\\[\\\\#153\\\\]\\\\/10,.bg-\\\\[\\\\#1533\\\\]\\\\/10{background-color:rgba(17,85,51,0.1);}
-.bg-custom-b{background-color:rgba(var(--custom), 1);}
+.bg-\\\\[\\\\#1533\\\\]{background-color:rgba(17,85,51,0.2);}
 .bg-\\\\#452233\\\\/40,.bg-hex-452233\\\\/40{background-color:rgba(69,34,51,0.4);}
+.bg-custom-b{background-color:rgba(var(--custom), 1);}
 .bg-red-100{--un-bg-opacity:1;background-color:rgba(254,226,226,var(--un-bg-opacity));}
 .bg-teal-100\\\\/55{background-color:rgba(204,251,241,0.55);}
 .bg-teal-200\\\\:55{background-color:rgba(153,246,228,0.55);}
@@ -115,8 +115,8 @@ exports[`targets 1`] = `
 .fill-current{fill:currentColor;}
 .fill-green-400{--un-fill-opacity:1;fill:rgba(74,222,128,var(--un-fill-opacity));}
 .fill-opacity-80{--un-fill-opacity:0.8;}
-.border{border-width:1px;border-style:solid;}
 .b-2,.border-2{border-width:2px;border-style:solid;}
+.border{border-width:1px;border-style:solid;}
 .border-b{border-bottom-width:1px;border-style:solid;}
 .border-t-2{border-top-width:2px;border-style:solid;}
 .border-custom-b\\\\/10{border-color:rgba(var(--custom), 0.1);}
@@ -171,9 +171,9 @@ exports[`targets 1`] = `
 .text-black\\\\/10{color:rgba(0,0,0,0.1);}
 .text-blue{--un-text-opacity:1;color:rgba(96,165,250,var(--un-text-opacity));}
 .text-custom-a{color:var(--custom);}
+.text-red-100,.text-red100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}
 .text-red-200\\\\/10{color:rgba(254,202,202,0.1);}
 .text-red-300\\\\/20{color:rgba(252,165,165,0.2);}
-.text-red-100,.text-red100{--un-text-opacity:1;color:rgba(254,226,226,var(--un-text-opacity));}
 .text-red2{--un-text-opacity:1;color:rgba(254,202,202,var(--un-text-opacity));}
 .text-opacity-\\\\[13\\\\.3333333\\\\%\\\\]{--un-text-opacity:13.3333333%;}
 .italic{font-style:italic;}
@@ -378,7 +378,9 @@ exports[`targets 1`] = `
 .table-row-group{display:table-row-group;}
 .preserve-3d{transform-style:preserve-3d;}
 .preserve-flat{transform-style:flat;}
+.-translate-full,.-translate-x-full,.-translate-y-1\\\\/2{--un-rotate:-0;--un-scale-x:-1;--un-scale-y:-1;--un-scale-z:-1;--un-skew-x:-0;--un-skew-y:-0;--un-translate-x:-0;--un-translate-y:-0;--un-translate-z:-0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;}
+.translate-full,.translate-x-full,.translate-y-1\\\\/4{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .translate-full{--un-translate-x:100%;--un-translate-y:100%;}
 .-translate-x-full{--un-translate-x:-100%;}
 .-translate-y-1\\\\/2{--un-translate-y:-50%;}


### PR DESCRIPTION
Another solution of #197, /cc @chu121su12

Instead of allowing match multiple rules (which will make the overriding impossible and hard to resolve when there are conflicts), this PR allow rules to return an array of css object to multiple css selectors.

```ts
rules: [
  [/^scale-(\d+)$/, ([, d]) => {
    return [
      { transform: 'var(--scale)' },
      { --scale: d }
    ]
  }
]
```

Which make it generates 

```css
.scale-100 {
  transform: var(--scale);
}
.scale-100 {
  --scale: 100
}
```

And [Rules Merging](https://github.com/antfu/unocss#rules-merging) could merge the duplicated parts.