### PR TITLE
feat(preset-mini): new text-[sizes] behaviour

### DIFF
--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -27,10 +27,14 @@ const weightMap: Record<string, string> = {
 }
 
 export const fontSizes: Rule<Theme>[] = [
-  [/^text-([^-]+)$/, ([, s = 'base'], { theme }) => {
-    const result = toArray(theme.fontSize?.[s] || h.bracket.rem(s))
-    if (result?.[0]) {
-      const [size, height = '1'] = result
+  [/^text-(.+)$/, ([, s = 'base'], { theme }) => {
+    const size = h.bracket.rem(s)
+    if (size)
+      return { 'font-size': size }
+
+    const themed = toArray(theme.fontSize?.[s])
+    if (themed?.[0]) {
+      const [size, height] = themed
       return {
         'font-size': size,
         'line-height': height,

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -87,6 +87,8 @@ exports[`targets 1`] = `
 .font-mono{font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,\\"Liberation Mono\\",\\"Courier New\\",monospace;}
 .dark .dark\\\\:text-xl{font-size:1.25rem;line-height:1.75rem;}
 .light .light\\\\:text-sm{font-size:0.875rem;line-height:1.25rem;}
+.text-\\\\[2em\\\\]{font-size:2em;}
+.text-\\\\[calc\\\\(1em-1px\\\\)\\\\]{font-size:calc(1em - 1px);}
 .text-4xl{font-size:2.25rem;line-height:2.5rem;}
 .text-base{font-size:1rem;line-height:1.5rem;}
 .text-lg{font-size:1.125rem;line-height:1.75rem;}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -163,6 +163,8 @@ const targets = [
   'table-footer-group',
   'table-row-group',
   'text-[#124]',
+  'text-[2em]',
+  'text-[calc(1em-1px)]',
   'text-4xl',
   'text-base',
   'text-black/10',


### PR DESCRIPTION
- Ignore `line-height` when not themed (should be breaking if one's expecting line-height of 1 is set on this rule)
- Allow matching wildcard. Due to rule order, color will be matched first, so the default rule for unknown `text-[value]` is `color: value`

Related: #202 