### PR TITLE
fix(preset-wind): bg-cover should be background-size

### DIFF
--- a/packages/preset-wind/src/rules/background.ts
+++ b/packages/preset-wind/src/rules/background.ts
@@ -150,6 +150,6 @@ export const bgRepeats: Rule[] = [
 
 export const bgSizes: Rule[] = [
   ['bg-auto', { 'background-size': 'auto' }],
-  ['bg-cover', { 'background-repeat': 'cover' }],
-  ['bg-contain', { 'background-position': 'contain' }],
+  ['bg-cover', { 'background-size': 'cover' }],
+  ['bg-contain', { 'background-size': 'contain' }],
 ]


### PR DESCRIPTION
- bg-cover mean `background-size:cover`

More info:

- [background-size | MDN](https://developer.mozilla.org/zh-CN/docs/Web/CSS/background-size)
- [background-size | windicss](https://windicss.org/utilities/backgrounds.html#background-size)