### PR TITLE
feat(preset-main): font-size for font-size-var

### DIFF
--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -41,6 +41,11 @@ export const fontSizes: Rule<Theme>[] = [
       }
     }
   }],
+  [/^font-size-(.+)$/, ([, s]) => {
+    const raw = h.bracket.rem(s)
+    if (raw)
+      return { 'font-size': raw }
+  }],
 ]
 
 export const fontWeights: Rule[] = [


### PR DESCRIPTION
Rule to reliably target `font-size` alone. 

Alternative of #223 