### PR TITLE
docs: svelte extractor fixtures and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -113,18 +113,18 @@ Refer to the full documentation on https://github.com/antfu/unocss/tree/main/pac
 
 You must add `Unocss` plugin before `@sveltejs/vite-plugin-svelte`.
 
-To support `class:foo` and `class:foo={bar}` add `Unocss` and configure `svelteExtractor`:
+To support `class:foo` and `class:foo={bar}` add `Unocss` and configure `extractorSvelte`:
 
 ```ts
 // vite.config.js
 import { svelte } from '@sveltejs/vite-plugin-svelte'
 import Unocss from 'unocss/vite'
-import { svelteExtractor } from '@unocss/core'
+import { extractorSvelte } from '@unocss/core'
 
 export default {
   plugins: [
     Unocss({
-      extractors: [svelteExtractor],
+      extractors: [extractorSvelte],
       /* options */
     }),
     svelte()
@@ -134,13 +134,13 @@ export default {
 
 ###  Sveltekit
 
-To support `class:foo` and `class:foo={bar}` add `Unocss` plugin and configure `svelteExtractor`:
+To support `class:foo` and `class:foo={bar}` add `Unocss` plugin and configure `extractorSvelte`:
 
 ```ts
 // svelte.config.js
 import preprocess from 'svelte-preprocess'
 import UnoCss from 'unocss/vite'
-import { svelteExtractor } from '@unocss/core'
+import { extractorSvelte } from '@unocss/core'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
@@ -155,7 +155,7 @@ const config = {
     vite: {
       plugins: [
         UnoCss({
-          extractors: [svelteExtractor],
+          extractors: [extractorSvelte],
           /* options */
         })
       ]

--- a/test/fixtures/sveltekit/package.json
+++ b/test/fixtures/sveltekit/package.json
@@ -14,6 +14,7 @@
     "@sveltejs/adapter-static": "next",
     "@sveltejs/kit": "next",
     "@unocss/preset-icons": "link:../../../packages/presets-icons",
+    "@unocss/core": "link:../../../packages/core",
     "svelte": "^3.44.2",
     "svelte-check": "^2.2.10",
     "svelte-preprocess": "^4.9.8",

--- a/test/fixtures/sveltekit/svelte.config.js
+++ b/test/fixtures/sveltekit/svelte.config.js
@@ -1,7 +1,7 @@
 import adapter from '@sveltejs/adapter-static'
 import preprocess from 'svelte-preprocess'
 import UnoCss from 'unocss/vite'
-import { svelteExtractor } from '@unocss/core'
+import { extractorSvelte } from '@unocss/core'
 import presetIcons from '@unocss/preset-icons'
 import presetUno from '@unocss/preset-uno'
 
@@ -19,7 +19,7 @@ const config = {
     vite: {
       plugins: [
         UnoCss({
-          extractors: [svelteExtractor],
+          extractors: [extractorSvelte],
           shortcuts: [
             { logo: 'i-logos-svelte-icon w-6em h-6em transform transition-800 hover:rotate-180' },
             { foo: 'bg-yellow-400' },

--- a/test/fixtures/vite-svelte/package.json
+++ b/test/fixtures/vite-svelte/package.json
@@ -13,6 +13,7 @@
     "@sveltejs/vite-plugin-svelte": "^1.0.0-next.31",
     "@tsconfig/svelte": "^2.0.1",
     "@unocss/preset-icons": "link:../../../packages/presets-icons",
+    "@unocss/core": "link:../../../packages/core",
     "svelte": "^3.44.2",
     "svelte-check": "^2.2.10",
     "svelte-preprocess": "^4.9.8",

--- a/test/fixtures/vite-svelte/src/App.svelte
+++ b/test/fixtures/vite-svelte/src/App.svelte
@@ -3,6 +3,7 @@
     import Footer from './Footer.svelte'
     let logo = false
     let red = false
+    let x = 'abc?cbd'
     function toggleLogo() {
         logo = !logo
     }
@@ -11,6 +12,7 @@
     }
     $: button = logo ? 'Hide logo' : 'Show logo'
     $: span = red ? 'Normal' : 'Red'
+    $: console.log(x)
 </script>
 
 <main>

--- a/test/fixtures/vite-svelte/vite.config.js
+++ b/test/fixtures/vite-svelte/vite.config.js
@@ -3,13 +3,13 @@ import { svelte } from '@sveltejs/vite-plugin-svelte'
 import UnoCss from 'unocss/vite'
 import presetIcons from '@unocss/preset-icons'
 import presetUno from '@unocss/preset-uno'
-import { svelteExtractor } from '@unocss/core'
+import { extractorSvelte } from '@unocss/core'
 
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [
     UnoCss({
-      extractors: [svelteExtractor],
+      extractors: [extractorSvelte],
       shortcuts: [
         { logo: 'i-logos-svelte-icon w-6em h-6em transform transition-800 hover:rotate-180' },
         { foo: 'bg-yellow-400' },


### PR DESCRIPTION
There is some typo on the name, it is `extractorSvelte` not `svelteExtractor`.

This PR only updates the `fixtures` and the installation section on root `README.md`.

/cc @dominikg 