### PR TITLE
feat(preset-mini): remove `next:` variant (breaking)

### DIFF
--- a/packages/preset-mini/src/variants/combinators.ts
+++ b/packages/preset-mini/src/variants/combinators.ts
@@ -4,7 +4,6 @@ import { variantMatcher } from '../utils'
 export const variantCombinators: Variant[] = [
   variantMatcher('all', input => `${input} *`),
   variantMatcher('children', input => `${input}>*`),
-  variantMatcher('next', input => `${input}+*`),
   variantMatcher('sibling', input => `${input}+*`),
   variantMatcher('siblings', input => `${input}~*`),
   variantMatcher('svg', input => `${input} svg *`),

--- a/test/__snapshots__/preset-uno.test.ts.snap
+++ b/test/__snapshots__/preset-uno.test.ts.snap
@@ -25,7 +25,7 @@ exports[`targets 1`] = `
 .-mb-px{margin-bottom:-1px;}
 .mt-\\\\[-10\\\\.2\\\\%\\\\]{margin-top:-10.2%;}
 .mt-\\\\$height{margin-top:var(--height);}
-.next\\\\:mt-0+*{margin-top:0rem;}
+.sibling\\\\:mt-0+*{margin-top:0rem;}
 .box-border{box-sizing:border-box;}
 .box-content{box-sizing:content-box;}
 .aspect-ratio-auto{aspect-ratio:auto;}

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -176,7 +176,7 @@ const targets = [
   'space-y-4',
   '-space-x-4',
   'space-x-reverse',
-  'next:mt-0',
+  'sibling:mt-0',
   'italic',
   'lining-nums',
   'normal-nums',


### PR DESCRIPTION
May be reused for tagged variant like group/peer