### PR TITLE
feat: add `shadow-dom` support

### DIFF
--- a/packages/plugins-common/constants.ts
+++ b/packages/plugins-common/constants.ts
@@ -1,2 +1,3 @@
 export const INCLUDE_COMMENT = '@unocss-include'
 export const INCLUDE_COMMENT_IDE = '@unocss-ide-include'
+export const CSS_PLACEHOLDER = '@unocss-placeholder'

--- a/packages/plugins-common/constants.ts
+++ b/packages/plugins-common/constants.ts
@@ -1,2 +1,3 @@
+export const IMPORT_CSS = '@unocss-import'
 export const INCLUDE_COMMENT = '@unocss-include'
 export const INCLUDE_COMMENT_IDE = '@unocss-ide-include'

--- a/packages/plugins-common/constants.ts
+++ b/packages/plugins-common/constants.ts
@@ -1,3 +1,2 @@
-export const IMPORT_CSS = '@unocss-import'
 export const INCLUDE_COMMENT = '@unocss-include'
 export const INCLUDE_COMMENT_IDE = '@unocss-ide-include'

--- a/packages/plugins-common/context.ts
+++ b/packages/plugins-common/context.ts
@@ -3,7 +3,7 @@ import type { LoadConfigResult, LoadConfigSource } from '@unocss/config'
 import { createConfigLoader } from '@unocss/config'
 import type { UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { BetterMap, createGenerator } from '@unocss/core'
-import { INCLUDE_COMMENT } from './constants'
+import { CSS_PLACEHOLDER, INCLUDE_COMMENT } from './constants'
 import { defaultExclude, defaultInclude } from './defaults'
 
 export interface UnocssPluginContext<Config extends UserConfig = UserConfig> {
@@ -70,7 +70,7 @@ export function createContext<Config extends UserConfig = UserConfig>(
   }
 
   const filter = (code: string, id: string) => {
-    return code.includes(INCLUDE_COMMENT) || rollupFilter(id)
+    return code.includes(INCLUDE_COMMENT) || code.includes(CSS_PLACEHOLDER) || rollupFilter(id)
   }
 
   async function getConfig() {

--- a/packages/plugins-common/context.ts
+++ b/packages/plugins-common/context.ts
@@ -3,7 +3,7 @@ import type { LoadConfigResult, LoadConfigSource } from '@unocss/config'
 import { createConfigLoader } from '@unocss/config'
 import type { UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { BetterMap, createGenerator } from '@unocss/core'
-import { INCLUDE_COMMENT } from './constants'
+import { IMPORT_CSS, INCLUDE_COMMENT } from './constants'
 import { defaultExclude, defaultInclude } from './defaults'
 
 export interface UnocssPluginContext<Config extends UserConfig = UserConfig> {
@@ -70,7 +70,7 @@ export function createContext<Config extends UserConfig = UserConfig>(
   }
 
   const filter = (code: string, id: string) => {
-    return code.includes(INCLUDE_COMMENT) || rollupFilter(id)
+    return code.includes(IMPORT_CSS) || code.includes(INCLUDE_COMMENT) || rollupFilter(id)
   }
 
   async function getConfig() {

--- a/packages/plugins-common/context.ts
+++ b/packages/plugins-common/context.ts
@@ -3,7 +3,7 @@ import type { LoadConfigResult, LoadConfigSource } from '@unocss/config'
 import { createConfigLoader } from '@unocss/config'
 import type { UnoGenerator, UserConfig, UserConfigDefaults } from '@unocss/core'
 import { BetterMap, createGenerator } from '@unocss/core'
-import { IMPORT_CSS, INCLUDE_COMMENT } from './constants'
+import { INCLUDE_COMMENT } from './constants'
 import { defaultExclude, defaultInclude } from './defaults'
 
 export interface UnocssPluginContext<Config extends UserConfig = UserConfig> {
@@ -70,7 +70,7 @@ export function createContext<Config extends UserConfig = UserConfig>(
   }
 
   const filter = (code: string, id: string) => {
-    return code.includes(IMPORT_CSS) || code.includes(INCLUDE_COMMENT) || rollupFilter(id)
+    return code.includes(INCLUDE_COMMENT) || rollupFilter(id)
   }
 
   async function getConfig() {

--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -3,7 +3,7 @@ import type { Theme } from '../theme'
 import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
 import { variantImportant, variantNegative, variantSpace } from './misc'
-import { variantPseudoClasses, variantPseudoElements } from './pseudo'
+import { partClasses, variantPseudoClasses, variantPseudoElements } from './pseudo'
 
 export const variants: Variant<Theme>[] = [
   variantSpace,
@@ -13,4 +13,5 @@ export const variants: Variant<Theme>[] = [
   ...variantCombinators,
   variantPseudoClasses,
   variantPseudoElements,
+  partClasses,
 ]

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -55,7 +55,7 @@ const PseudoElements = [
   'selection',
 ]
 
-const PartClassesRE = /(part-\[(.*)]:)(.*)/
+const PartClassesRE = /(part-\[(.+)]:)(.+)/
 const PseudoElementsRE = new RegExp(`^(${PseudoElements.join('|')})[:-]`)
 
 const PseudoClassesStr = Object.keys(PseudoClasses).join('|')

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -55,6 +55,7 @@ const PseudoElements = [
   'selection',
 ]
 
+const PartClassesRE = /(part-\[(.*)]:)(.*)/
 const PseudoElementsRE = new RegExp(`^(${PseudoElements.join('|')})[:-]`)
 
 const PseudoClassesStr = Object.keys(PseudoClasses).join('|')
@@ -120,6 +121,22 @@ export const variantPseudoClasses: VariantObject = {
         selector: (s, body) => shouldAdd(body) && s.includes('.peer:')
           ? s.replace(/\.peer:/, `.peer:${pseudo}:`)
           : `.peer:${pseudo}~${s}`,
+      }
+    }
+  },
+  multiPass: true,
+}
+
+export const partClasses: VariantObject = {
+  match: (input: string) => {
+    const match = input.match(PartClassesRE)
+    if (match) {
+      const part = `part(${match[2]})`
+      return {
+        matcher: input.slice(match[1].length),
+        selector: (s, body) => {
+          return shouldAdd(body) && `${s}::${part}`
+        },
       }
     }
   },

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -6,6 +6,7 @@ import { ChunkModeBuildPlugin } from './modes/chunk-build'
 import { GlobalModeDevPlugin, GlobalModePlugin } from './modes/global'
 import { PerModuleModePlugin } from './modes/per-module'
 import { VueScopedPlugin } from './modes/vue-scoped'
+import { ShadowDomModuleModePlugin } from './modes/shadow-dom'
 import { ConfigHMRPlugin } from './config-hmr'
 import type { VitePluginConfig } from './types'
 
@@ -41,6 +42,9 @@ export default function UnocssPlugin(
   }
   else if (mode === 'vue-scoped') {
     plugins.push(VueScopedPlugin(ctx))
+  }
+  else if (mode === 'shadow-dom') {
+    plugins.push(ShadowDomModuleModePlugin(ctx))
   }
   else if (mode === 'global') {
     plugins.push(...GlobalModePlugin(ctx))

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -64,10 +64,10 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
 
         return acc
       }, new Array<PartData>())
-      const partsToApply = new Map<string, Array<string>>()
       if (useParts.length > 0) {
         let useCode = code
         let element: RegExpExecArray | null
+        const partsToApply = new Map<string, Array<string>>()
         const { elementIdxMap, idxResolver } = idxMapFactory()
         // We need to traverse the code to find the web components using the original class/attr part.
         // We need traverse the code to apply the same order the components are on the code: we are using nth-of-type.

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -15,6 +15,7 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
     let { css, matched } = await uno.generate(code, { preflights: false })
 
     if (css && matched) {
+      // check if we need to apply some ::part
       const partsToApply = Array.from(matched).reduce((acc, e) => {
         if (e.match(partRegex)) {
           const cssEntryRegex = `\\\.${e.replace(
@@ -39,7 +40,7 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
 
         return acc
       }, new Map<string, string>())
-      if (partsToApply) {
+      if (partsToApply.size > 0) {
         css = Array.from(partsToApply.entries()).reduce((k, [r, name]) => {
           let regexp = cache.get(r)
           if (!regexp) {

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -1,6 +1,6 @@
 import type { Plugin } from 'vite'
 import type { UnocssPluginContext } from '../../../plugins-common'
-import { INCLUDE_COMMENT } from '../../../plugins-common'
+import { CSS_PLACEHOLDER } from '../../../plugins-common'
 
 export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin {
   const partExtractorRegex = /^part-\[(.+)]:/
@@ -44,7 +44,7 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
     }
   }
   const transformWebComponent = async(code: string) => {
-    if (!code.match(INCLUDE_COMMENT))
+    if (!code.match(CSS_PLACEHOLDER))
       return code
 
     // eslint-disable-next-line prefer-const
@@ -95,7 +95,7 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
       }
     }
 
-    return code.replace(INCLUDE_COMMENT, css || '')
+    return code.replace(CSS_PLACEHOLDER, css || '')
   }
 
   return {

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -1,10 +1,10 @@
 import type { Plugin } from 'vite'
 import type { UnocssPluginContext } from '../../../plugins-common'
-import { INCLUDE_COMMENT } from '../../../plugins-common'
+import { IMPORT_CSS } from '../../../plugins-common'
 
 export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin {
   async function transformWebComponent(code: string) {
-    const imported = code.match(INCLUDE_COMMENT)
+    const imported = code.match(IMPORT_CSS)
     if (!imported)
       return code
 
@@ -12,7 +12,7 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
     if (!css)
       return code
 
-    return code.replace(INCLUDE_COMMENT, css)
+    return code.replace(IMPORT_CSS, css)
   }
 
   return {

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -1,0 +1,32 @@
+import type { Plugin } from 'vite'
+import type { UnocssPluginContext } from '../../../plugins-common'
+import { INCLUDE_COMMENT } from '../../../plugins-common'
+
+export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin {
+  async function transformWebComponent(code: string) {
+    const imported = code.match(INCLUDE_COMMENT)
+    if (!imported)
+      return code
+
+    const { css } = await uno.generate(code, { preflights: false })
+    if (!css)
+      return code
+
+    return code.replace(INCLUDE_COMMENT, css)
+  }
+
+  return {
+    name: 'unocss:shadow-dom',
+    enforce: 'pre',
+    async transform(code) {
+      return transformWebComponent(code)
+    },
+    handleHotUpdate(ctx) {
+      const read = ctx.read
+      ctx.read = async() => {
+        const code = await read()
+        return await transformWebComponent(code)
+      }
+    },
+  }
+}

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -3,9 +3,30 @@ import type { UnocssPluginContext } from '../../../plugins-common'
 import { IMPORT_CSS } from '../../../plugins-common'
 
 export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin {
-  const partRegex = /^part-\[.*]:/
   const partExtractorRegex = /^part-\[(.+)]:/
-  const nameRegexp = /<([^\s>]+)\s*([^>]*)>/
+  const nameRegexp = /<([^\s^!>]+)\s*([^>]*)>/
+  type PartData = {
+    part: string
+    rule: string
+  }
+  const checkElement = (useParts: PartData[], idxResolver: (name: string) => number, element: RegExpExecArray | null) => {
+    if (!element)
+      return null
+
+    return useParts.filter(p => element[2].includes(p.rule)).map(({ rule, part }) => {
+      const idx = idxResolver(element[1])
+      return [
+        element[1],
+        `.${rule.replace(
+          /\[/g, '\\[',
+        ).replace(
+          /]/g, '\\]',
+        ).replace(
+          /:/g, '\\:')}::part(${part})`,
+        `${element[1]}:nth-of-type(${idx})::part(${part})`,
+      ]
+    })
+  }
   async function transformWebComponent(code: string) {
     const imported = code.match(IMPORT_CSS)
     if (!imported)
@@ -15,38 +36,57 @@ export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin 
     let { css, matched } = await uno.generate(code, { preflights: false })
 
     if (css && matched) {
-      let i = 1
-      // check if we need to apply some ::part
-      const partsToApply = Array.from(matched).reduce((acc, e) => {
-        if (e.match(partRegex)) {
-          let element: RegExpExecArray | null
-          let useCode = code
-          // eslint-disable-next-line no-cond-assign
-          while (element = nameRegexp.exec(useCode)) {
-            if (element[2].includes(e)) {
-              const part = e.match(partExtractorRegex)![1]
-              const cssEntryRegex = `${i}-.${e.replace(
-                /\[/g, '\\[',
-              ).replace(
-                /]/g, '\\]',
-              ).replace(
-                /:/g, '\\:')}::part(${part})`
-              acc.set(
-                cssEntryRegex,
-                `${element[1]}:nth-of-type(${i})::part(${part})`,
-              )
-              i++
-            }
-            useCode = useCode.slice(element[0].length + 1)
-          }
-        }
+      // filter only parts from the result reported from the generator
+      const useParts = Array.from(matched).reduce((acc, rule) => {
+        const matcher = rule.match(partExtractorRegex)
+        if (matcher)
+          acc.push({ part: matcher[1], rule })
 
         return acc
-      }, new Map<string, string>())
-      if (partsToApply.size > 0) {
-        css = Array.from(partsToApply.entries()).reduce((k, [r, name]) => {
-          return k.replace(r.slice(r.indexOf('-') + 1), name)
-        }, css)
+      }, new Array<PartData>())
+      const partsToApply = new Map<string, Array<string>>()
+      if (useParts.length > 0) {
+        let useCode = code
+        let element: RegExpExecArray | null
+        const elementIdxMap = new Map<string, number>()
+        // We need to traverse the code to find the web components using the original class/attr part.
+        // We need traverse the code to apply the same order the components are on the code.
+        // A web component can have multiple parts, and so, we need to collect all of them: see checkElement above.
+        const idxResolver = (name: string): number => {
+          let idx = elementIdxMap.get(name)
+          if (!idx) {
+            idx = 1
+            elementIdxMap.set(name, idx)
+          }
+          return idx
+        }
+        // eslint-disable-next-line no-cond-assign
+        while (element = nameRegexp.exec(useCode)) {
+          const result = checkElement(
+            useParts,
+            idxResolver,
+            element,
+          )
+          if (result && result.length > 0) {
+            // the first element is the web component name
+            result.forEach(([, name, replacement]) => {
+              let list = partsToApply.get(name)
+              if (!list) {
+                list = []
+                partsToApply.set(name, list)
+              }
+              list.push(replacement)
+            })
+            const [name] = result[0]
+            elementIdxMap.set(name, elementIdxMap.get(name)! + 1)
+          }
+          useCode = useCode.slice(element[0].length + 1)
+        }
+        if (partsToApply.size > 0) {
+          css = Array.from(partsToApply.entries()).reduce((k, [r, name]) => {
+            return k.replace(r, name.join(',\n'))
+          }, css)
+        }
       }
     }
 

--- a/packages/vite/src/modes/shadow-dom.ts
+++ b/packages/vite/src/modes/shadow-dom.ts
@@ -3,12 +3,54 @@ import type { UnocssPluginContext } from '../../../plugins-common'
 import { IMPORT_CSS } from '../../../plugins-common'
 
 export function ShadowDomModuleModePlugin({ uno }: UnocssPluginContext): Plugin {
+  const partRegex = /^part-\[.*]:/
+  const nameRegexp = /<([^\s>]+)\s*([^>]*)>/
+  const cache = new Map<string, RegExp>()
   async function transformWebComponent(code: string) {
     const imported = code.match(IMPORT_CSS)
     if (!imported)
       return code
 
-    const { css } = await uno.generate(code, { preflights: false })
+    // eslint-disable-next-line prefer-const
+    let { css, matched } = await uno.generate(code, { preflights: false })
+
+    if (css && matched) {
+      const partsToApply = Array.from(matched).reduce((acc, e) => {
+        if (e.match(partRegex)) {
+          const cssEntryRegex = `\\\.${e.replace(
+            /\[/g, '\\\\\\\[',
+          ).replace(
+            /]/g, '\\\\\\\]',
+          ).replace(
+            /:/g, '\\\\\\:')}`
+          let element: RegExpExecArray | null
+          let useCode = code
+          // eslint-disable-next-line no-cond-assign
+          while (element = nameRegexp.exec(useCode)) {
+            if (element[2].includes(e)) {
+              acc.set(
+                cssEntryRegex,
+                element[1],
+              )
+            }
+            useCode = useCode.slice(element[0].length + 1)
+          }
+        }
+
+        return acc
+      }, new Map<string, string>())
+      if (partsToApply) {
+        css = Array.from(partsToApply.entries()).reduce((k, [r, name]) => {
+          let regexp = cache.get(r)
+          if (!regexp) {
+            regexp = new RegExp(`(${r})`, 'g')
+            cache.set(r, regexp)
+          }
+          return k.replace(regexp, name)
+        }, css)
+      }
+    }
+
     return code.replace(IMPORT_CSS, css || '')
   }
 

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -18,5 +18,5 @@ export interface VitePluginConfig<Theme extends {} = {}> extends UserConfig<Them
    *
    * @default 'global'
    */
-  mode?: 'global' | 'per-module' | 'vue-scoped' | 'dist-chunk'
+  mode?: 'global' | 'per-module' | 'vue-scoped' | 'dist-chunk' | 'shadow-dom'
 }

--- a/test/fixtures/vite-lit/.gitignore
+++ b/test/fixtures/vite-lit/.gitignore
@@ -1,0 +1,6 @@
+node_modules
+.DS_Store
+dist
+types
+*.local
+.idea/

--- a/test/fixtures/vite-lit/.npmrc
+++ b/test/fixtures/vite-lit/.npmrc
@@ -1,0 +1,1 @@
+shamefully-hoist=true

--- a/test/fixtures/vite-lit/index.html
+++ b/test/fixtures/vite-lit/index.html
@@ -1,0 +1,14 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Vite + Lit App</title>
+    <script type="module" src="/src/my-element.ts"></script>
+  </head>
+  <body>
+    <my-element>
+      <p>This is child content</p>
+    </my-element>
+  </body>
+</html>

--- a/test/fixtures/vite-lit/index.html
+++ b/test/fixtures/vite-lit/index.html
@@ -5,10 +5,12 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>Vite + Lit App</title>
     <script type="module" src="/src/my-element.ts"></script>
+    <script type="module" src="/src/my-another-element.ts"></script>
   </head>
   <body>
     <my-element>
       <p>This is child content</p>
     </my-element>
+    <my-another-element>Click me</my-another-element>
   </body>
 </html>

--- a/test/fixtures/vite-lit/package.json
+++ b/test/fixtures/vite-lit/package.json
@@ -1,0 +1,30 @@
+{
+  "name": "unocss-lit-ts",
+  "version": "0.0.0",
+  "main": "dist/my-element.es.js",
+  "exports": {
+    ".": "./dist/my-element.es.js"
+  },
+  "types": "types/my-element.d.ts",
+  "files": [
+    "dist",
+    "types"
+  ],
+  "scripts": {
+    "dev": "vite",
+    "build": "tsc && vite build"
+  },
+  "dependencies": {
+    "lit": "^2.0.0"
+  },
+  "devDependencies": {
+    "@iconify-json/logos": "^1.0.1",
+    "@unocss/core": "link:../../../packages/core",
+    "@unocss/preset-icons": "link:../../../packages/presets-icons",
+    "@unocss/preset-attributify": "link:../../../packages/preset-attributify",
+    "typescript": "^4.3.2",
+    "unocss": "link:../../../packages/unocss",
+    "vite": "^2.6.4",
+    "vite-plugin-inspect": "^0.3.11"
+  }
+}

--- a/test/fixtures/vite-lit/src/my-another-element.ts
+++ b/test/fixtures/vite-lit/src/my-another-element.ts
@@ -1,7 +1,7 @@
 const template = document.createElement('template')
 template.innerHTML = `
 <style>
-@unocss-import
+@unocss-include
 </style>
 <div class="m-1em">
   <button class="bg-green-300"><slot></slot></button>

--- a/test/fixtures/vite-lit/src/my-another-element.ts
+++ b/test/fixtures/vite-lit/src/my-another-element.ts
@@ -1,7 +1,7 @@
 const template = document.createElement('template')
 template.innerHTML = `
 <style>
-@unocss-include
+@unocss-placeholder
 </style>
 <div class="m-1em">
   <button class="bg-green-300"><slot></slot></button>

--- a/test/fixtures/vite-lit/src/my-another-element.ts
+++ b/test/fixtures/vite-lit/src/my-another-element.ts
@@ -1,0 +1,36 @@
+const template = document.createElement('template')
+template.innerHTML = `
+<style>
+@unocss-import
+</style>
+<button class="bg-green-300"><slot></slot></button>
+`
+
+export class MyAnotherElement extends HTMLElement {
+  _clicked = false
+
+  constructor() {
+    super()
+  }
+
+  connectedCallback() {
+    this.attachShadow({ mode: 'open' })
+    this.shadowRoot?.appendChild(template.content.cloneNode(true))
+    const button = this.shadowRoot?.querySelector('button')
+    button?.addEventListener('click', this._handleClick.bind(this))
+  }
+
+  _handleClick() {
+    this._clicked = !this._clicked
+    const button = this.shadowRoot?.querySelector('button')
+    if (this._clicked) {
+      button?.classList?.remove('bg-green-300')
+      button?.classList?.add('bg-blue-300')
+    }
+    else {
+      button?.classList?.remove('bg-blue-300')
+      button?.classList?.add('bg-green-300')
+    }
+  }
+}
+window.customElements.define('my-another-element', MyAnotherElement)

--- a/test/fixtures/vite-lit/src/my-another-element.ts
+++ b/test/fixtures/vite-lit/src/my-another-element.ts
@@ -3,7 +3,10 @@ template.innerHTML = `
 <style>
 @unocss-import
 </style>
-<button class="bg-green-300"><slot></slot></button>
+<div class="m-1em">
+  <button class="bg-green-300"><slot></slot></button>
+  <div part="cool-part">Testing part</div>
+</div>
 `
 
 export class MyAnotherElement extends HTMLElement {

--- a/test/fixtures/vite-lit/src/my-collision-element.ts
+++ b/test/fixtures/vite-lit/src/my-collision-element.ts
@@ -1,7 +1,7 @@
 const template = document.createElement('template')
 template.innerHTML = `
 <style>
-@unocss-include
+@unocss-placeholder
 </style>
 <div class="m-1em">
   <button class="bg-red-300"><slot></slot></button>

--- a/test/fixtures/vite-lit/src/my-collision-element.ts
+++ b/test/fixtures/vite-lit/src/my-collision-element.ts
@@ -1,7 +1,7 @@
 const template = document.createElement('template')
 template.innerHTML = `
 <style>
-@unocss-import
+@unocss-include
 </style>
 <div class="m-1em">
   <button class="bg-red-300"><slot></slot></button>

--- a/test/fixtures/vite-lit/src/my-collision-element.ts
+++ b/test/fixtures/vite-lit/src/my-collision-element.ts
@@ -4,13 +4,13 @@ template.innerHTML = `
 @unocss-import
 </style>
 <div class="m-1em">
-  <button class="bg-green-300"><slot></slot></button>
+  <button class="bg-red-300"><slot></slot></button>
   <div part="cool-part">Testing part</div>
   <div part="another-cool-part">Testing another part</div>
 </div>
 `
 
-export class MyAnotherElement extends HTMLElement {
+export class MyCollisionElement extends HTMLElement {
   _clicked = false
 
   constructor() {
@@ -28,13 +28,13 @@ export class MyAnotherElement extends HTMLElement {
     this._clicked = !this._clicked
     const button = this.shadowRoot?.querySelector('button')
     if (this._clicked) {
-      button?.classList?.remove('bg-green-300')
-      button?.classList?.add('bg-blue-300')
+      button?.classList?.remove('bg-red-300')
+      button?.classList?.add('bg-yellow-300')
     }
     else {
-      button?.classList?.remove('bg-blue-300')
-      button?.classList?.add('bg-green-300')
+      button?.classList?.remove('bg-yellow-300')
+      button?.classList?.add('bg-red-300')
     }
   }
 }
-window.customElements.define('my-another-element', MyAnotherElement)
+window.customElements.define('my-collision-element', MyCollisionElement)

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -17,9 +17,6 @@ export class MyElement extends LitElement {
       padding: 16px;
       max-width: 800px;
     }
-    my-another-element::part(xcool-part) {
-      background-color: #fefefe;
-    }
     @unocss-import
   `
 

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -18,7 +18,7 @@ export class MyElement extends LitElement {
       padding: 16px;
       max-width: 800px;
     }
-    @unocss-include
+    @unocss-placeholder
   `
 
   /**

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -1,0 +1,74 @@
+import { LitElement, css, html } from 'lit'
+import { customElement, property } from 'lit/decorators.js'
+
+/**
+ * An example element.
+ *
+ * @slot - This element has a slot
+ * @csspart button - The button
+ */
+@customElement('my-element')
+export class MyElement extends LitElement {
+  static styles = css`
+    :host {
+      display: block;
+      border: solid 1px gray;
+      padding: 16px;
+      max-width: 800px;
+    }
+    @unocss-include
+  `
+
+  /**
+   * The name to say "Hello" to.
+   */
+  @property()
+    name = 'World'
+
+  /**
+   * The number of times the button has been clicked.
+   */
+  @property({ type: Number })
+    count = 0
+
+  /**
+   * The name to say "Hello" to.
+   */
+  @property()
+    span = false
+
+  render() {
+    return html`
+      <span class="logo"></span>
+      <h1 class="mt-6em animate-jack-in-the-box animate-2s" text-green-600>Hello, ${this.name}!</h1>
+      <br />
+      ${this.span ? html` <div class="bg-red-400">BG Color should change</div>` : html` <div>BG Color should change</div>`}
+      <br />
+      <button class="bg-red-100" @click=${this._onClick} part="button">
+        Click Count: ${this.count}
+      </button>
+      <button @click=${this._toggleSpan} part="button">
+        Change BG Color:: ${this.span ? 'Normal' : 'Red'}
+      </button>
+      <slot></slot>
+    `
+  }
+
+  private _onClick() {
+    this.count++
+  }
+
+  private _toggleSpan() {
+    this.span = !this.span
+  }
+
+  foo(): string {
+    return 'foo'
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'my-element': MyElement
+  }
+}

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -1,6 +1,6 @@
 import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
-import { MyAnotherElement } from './my-another-element'
+import './my-another-element'
 
 /**
  * An example element.

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -1,6 +1,7 @@
 import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
 import './my-another-element'
+import './my-collision-element'
 
 /**
  * An example element.
@@ -51,8 +52,15 @@ export class MyElement extends LitElement {
       <button @click=${this._toggleSpan} part="button">
         Change BG Color:: ${this.span ? 'Normal' : 'Red'}
       </button>
+      <my-another-element class="part-[cool-part]:cool-green part-[another-cool-part]:cool-green">Testing css part</my-another-element>
+      <my-another-element class="part-[cool-part]:cool-green part-[another-cool-part]:cool-blue">Testing css part</my-another-element>
+      <my-another-element class="part-[cool-part]:cool-blue  part-[another-cool-part]:cool-green">Testing css part</my-another-element>
+      <my-another-element class="part-[cool-part]:cool-blue  part-[another-cool-part]:cool-blue">Testing css part</my-another-element>
       <my-another-element class="part-[cool-part]:cool-green">Testing css part</my-another-element>
       <my-another-element class="part-[cool-part]:cool-blue">Testing css part</my-another-element>
+      <my-another-element class="part-[cool-part]:cool-blue">Testing css part</my-another-element>
+      <my-collision-element class="part-[cool-part]:cool-blue">Testing css part</my-collision-element>
+      <my-collision-element class="part-[cool-part]:cool-green">Testing css part</my-collision-element>
       <slot></slot>
     `
   }

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -1,5 +1,6 @@
 import { LitElement, css, html } from 'lit'
 import { customElement, property } from 'lit/decorators.js'
+import { MyAnotherElement } from './my-another-element'
 
 /**
  * An example element.
@@ -15,6 +16,9 @@ export class MyElement extends LitElement {
       border: solid 1px gray;
       padding: 16px;
       max-width: 800px;
+    }
+    my-another-element::part(xcool-part) {
+      background-color: #fefefe;
     }
     @unocss-import
   `
@@ -50,6 +54,8 @@ export class MyElement extends LitElement {
       <button @click=${this._toggleSpan} part="button">
         Change BG Color:: ${this.span ? 'Normal' : 'Red'}
       </button>
+      <my-another-element class="part-[cool-part]:cool-green">Testing css part</my-another-element>
+      <my-another-element class="part-[cool-part]:cool-blue">Testing css part</my-another-element>
       <slot></slot>
     `
   }

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -18,7 +18,7 @@ export class MyElement extends LitElement {
       padding: 16px;
       max-width: 800px;
     }
-    @unocss-import
+    @unocss-include
   `
 
   /**
@@ -42,7 +42,7 @@ export class MyElement extends LitElement {
   render() {
     return html`
       <span class="logo"></span>
-      <h1 class="mt-6em animate-jack-in-the-box animate-2s" text-green-600>Hello, ${this.name}!</h1>
+      <h1 class="mt-2em animate-jack-in-the-box animate-2s" text-green-600>Hello, ${this.name}!</h1>
       <br />
       ${this.span ? html` <div class="bg-red-400">BG Color should change</div>` : html` <div>BG Color should change</div>`}
       <br />

--- a/test/fixtures/vite-lit/src/my-element.ts
+++ b/test/fixtures/vite-lit/src/my-element.ts
@@ -16,7 +16,7 @@ export class MyElement extends LitElement {
       padding: 16px;
       max-width: 800px;
     }
-    @unocss-include
+    @unocss-import
   `
 
   /**

--- a/test/fixtures/vite-lit/src/vite-env.d.ts
+++ b/test/fixtures/vite-lit/src/vite-env.d.ts
@@ -1,0 +1,1 @@
+/// <reference types="vite/client" />

--- a/test/fixtures/vite-lit/tsconfig.json
+++ b/test/fixtures/vite-lit/tsconfig.json
@@ -1,0 +1,22 @@
+{
+  "compilerOptions": {
+    "module": "esnext",
+    "lib": ["es2017", "dom", "dom.iterable"],
+    "declaration": true,
+    "emitDeclarationOnly": true,
+    "outDir": "./types",
+    "rootDir": "./src",
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "experimentalDecorators": true,
+    "forceConsistentCasingInFileNames": true,
+    "useDefineForClassFields": false
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": []
+}

--- a/test/fixtures/vite-lit/vite.config.ts
+++ b/test/fixtures/vite-lit/vite.config.ts
@@ -21,6 +21,8 @@ export default defineConfig({
       mode: 'shadow-dom',
       shortcuts: [
         { logo: 'i-logos-webcomponents w-6em h-6em transform transition-800 hover:rotate-180' },
+        { 'cool-blue': 'bg-blue-500 text-white' },
+        { 'cool-green': 'bg-green-500 text-black' },
       ],
       presets: [
         presetUno(),

--- a/test/fixtures/vite-lit/vite.config.ts
+++ b/test/fixtures/vite-lit/vite.config.ts
@@ -1,0 +1,39 @@
+import { defineConfig } from 'vite'
+import UnoCss from 'unocss/vite'
+import presetIcons from '@unocss/preset-icons'
+import presetUno from '@unocss/preset-uno'
+import presetAttributify from '@unocss/preset-attributify'
+import ViteInspector from 'vite-plugin-inspect'
+
+// https://vitejs.dev/config/
+export default defineConfig({
+  build: {
+    lib: {
+      entry: 'src/my-element.ts',
+      formats: ['es'],
+    },
+    rollupOptions: {
+      external: /^lit/,
+    },
+  },
+  plugins: [
+    UnoCss({
+      mode: 'shadow-dom',
+      shortcuts: [
+        { logo: 'i-logos-webcomponents w-6em h-6em transform transition-800 hover:rotate-180' },
+      ],
+      presets: [
+        presetUno(),
+        presetAttributify(),
+        presetIcons({
+          extraProperties: {
+            'display': 'inline-block',
+            'vertical-align': 'middle',
+          },
+        }),
+      ],
+      inspector: false,
+    }),
+    ViteInspector(),
+  ],
+})


### PR DESCRIPTION
we need to add some documentation, the plugin just replace the `@unocss-import` with the generated css

supersedes #222 (`shadow-dom` part)

closes #169 