### PR TITLE
feat(preset-mini): add new flex feature

### DIFF
--- a/packages/preset-mini/src/rules/flex.ts
+++ b/packages/preset-mini/src/rules/flex.ts
@@ -10,7 +10,7 @@ export const flex: Rule[] = [
   ['flex-auto', { flex: '1 1 auto' }],
   ['flex-initial', { flex: '0 1 auto' }],
   ['flex-none', { flex: 'none' }],
-  [/^flex-(\[.+\])$/, ([, d]) => ({ flex: h.bracket(d) })],
+  [/^flex-(\[.+\])$/, ([, d]) => ({ flex: h.bracket(d).replace(/\d+\/\d+/, $1 => h.fraction($1)) })],
   ['flex-shrink', { 'flex-shrink': 1 }],
   ['flex-shrink-0', { 'flex-shrink': 0 }],
   ['flex-grow', { 'flex-grow': 1 }],

--- a/packages/preset-mini/src/rules/flex.ts
+++ b/packages/preset-mini/src/rules/flex.ts
@@ -10,7 +10,7 @@ export const flex: Rule[] = [
   ['flex-auto', { flex: '1 1 auto' }],
   ['flex-initial', { flex: '0 1 auto' }],
   ['flex-none', { flex: 'none' }],
-  [/^flex-(\[.+\])$/, ([, d]) => ({ flex: h.bracket(d).replace(/\d+\/\d+/, $1 => h.fraction($1)) })],
+  [/^flex-(\[.+\])$/, ([, d]) => ({ flex: h.bracket(d)!.replace(/\d+\/\d+/, $1 => h.fraction($1)!) })],
   ['flex-shrink', { 'flex-shrink': 1 }],
   ['flex-shrink-0', { 'flex-shrink': 0 }],
   ['flex-grow', { 'flex-grow': 1 }],

--- a/packages/preset-mini/src/rules/flex.ts
+++ b/packages/preset-mini/src/rules/flex.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '@unocss/core'
+import { handler as h } from '../utils'
 
 export const flex: Rule[] = [
   // base
@@ -9,7 +10,14 @@ export const flex: Rule[] = [
   ['flex-auto', { flex: '1 1 auto' }],
   ['flex-initial', { flex: '0 1 auto' }],
   ['flex-none', { flex: 'none' }],
-  [/^flex-\[(.+)\]$/, ([, d]) => ({ flex: d })],
+  [/^flex-\[(.+)\]$/, ([, d]) => {
+    if (/\d+\/\d+/.test(d))
+      d = d.replace(/\d+\/\d+/, $1 => h.fraction($1)!)
+    d = d.replace(/(?<![a-zA-Z]+)-(?=\w+)/g, ' ')
+    return {
+      flex: d,
+    }
+  }],
   ['flex-shrink', { 'flex-shrink': 1 }],
   ['flex-shrink-0', { 'flex-shrink': 0 }],
   ['flex-grow', { 'flex-grow': 1 }],

--- a/packages/preset-mini/src/rules/flex.ts
+++ b/packages/preset-mini/src/rules/flex.ts
@@ -10,14 +10,7 @@ export const flex: Rule[] = [
   ['flex-auto', { flex: '1 1 auto' }],
   ['flex-initial', { flex: '0 1 auto' }],
   ['flex-none', { flex: 'none' }],
-  [/^flex-\[(.+)\]$/, ([, d]) => {
-    if (/\d+\/\d+/.test(d))
-      d = d.replace(/\d+\/\d+/, $1 => h.fraction($1)!)
-    d = d.replace(/(?<![a-zA-Z]+)-(?=\w+)/g, ' ')
-    return {
-      flex: d,
-    }
-  }],
+  [/^flex-(\[.+\])$/, ([, d]) => ({ flex: h.bracket(d) })],
   ['flex-shrink', { 'flex-shrink': 1 }],
   ['flex-shrink-0', { 'flex-shrink': 0 }],
   ['flex-grow', { 'flex-grow': 1 }],

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -188,7 +188,7 @@ exports[`attributify > fixture2 1`] = `
 `;
 
 exports[`attributify > variant 1`] = `
-Array [
+[
   undefined,
   undefined,
   "bg-blue-400",

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -188,7 +188,7 @@ exports[`attributify > fixture2 1`] = `
 `;
 
 exports[`attributify > variant 1`] = `
-[
+Array [
   undefined,
   undefined,
   "bg-blue-400",

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -202,10 +202,10 @@ exports[`preset-mini > targets 1`] = `
 .ring-offset-op-5{--un-ring-offset-opacity:0.05;}
 .ring-inset{--un-ring-inset:inset;}
 .flex{display:flex;}
-.flex-\\\\[0-0-auto\\\\]{flex:0 0 auto;}
-.flex-\\\\[1-0-100\\\\%\\\\]{flex:1 0 100%;}
-.flex-\\\\[1-1-1\\\\/2\\\\]{flex:1 1 50%;}
-.flex-\\\\[1-auto\\\\]{flex:1 auto;}
+.flex-\\\\[0_0_auto\\\\]{flex:0 0 auto;}
+.flex-\\\\[1_0_100\\\\%\\\\]{flex:1 0 100%;}
+.flex-\\\\[1_1_1\\\\/2\\\\]{flex:1 1 1/2;}
+.flex-\\\\[1_auto\\\\]{flex:1 auto;}
 .flex-\\\\[fit-content\\\\]{flex:fit-content;}
 .flex-\\\\[hi\\\\]{flex:hi;}
 .flex-row{flex-direction:row;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -204,7 +204,7 @@ exports[`preset-mini > targets 1`] = `
 .flex{display:flex;}
 .flex-\\\\[0_0_auto\\\\]{flex:0 0 auto;}
 .flex-\\\\[1_0_100\\\\%\\\\]{flex:1 0 100%;}
-.flex-\\\\[1_1_1\\\\/2\\\\]{flex:1 1 1/2;}
+.flex-\\\\[1_1_1\\\\/2\\\\]{flex:1 1 50%;}
 .flex-\\\\[1_auto\\\\]{flex:1 auto;}
 .flex-\\\\[fit-content\\\\]{flex:fit-content;}
 .flex-\\\\[hi\\\\]{flex:hi;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -202,6 +202,11 @@ exports[`preset-mini > targets 1`] = `
 .ring-offset-op-5{--un-ring-offset-opacity:0.05;}
 .ring-inset{--un-ring-inset:inset;}
 .flex{display:flex;}
+.flex-\\\\[0-0-auto\\\\]{flex:0 0 auto;}
+.flex-\\\\[1-0-100\\\\%\\\\]{flex:1 0 100%;}
+.flex-\\\\[1-1-1\\\\/2\\\\]{flex:1 1 50%;}
+.flex-\\\\[1-auto\\\\]{flex:1 auto;}
+.flex-\\\\[fit-content\\\\]{flex:fit-content;}
 .flex-\\\\[hi\\\\]{flex:hi;}
 .flex-row{flex-direction:row;}
 .flex-col-reverse{flex-direction:column-reverse;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -170,6 +170,11 @@ export const presetMiniTargets: string[] = [
 
   // flex, gap
   'flex-[hi]',
+  'flex-[1-0-100%]',
+  'flex-[0-0-auto]',
+  'flex-[1-1-1/2]',
+  'flex-[1-auto]',
+  'flex-[fit-content]',
   'flex',
   'flex-row',
   'flex-col-reverse',

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -170,10 +170,10 @@ export const presetMiniTargets: string[] = [
 
   // flex, gap
   'flex-[hi]',
-  'flex-[1-0-100%]',
-  'flex-[0-0-auto]',
-  'flex-[1-1-1/2]',
-  'flex-[1-auto]',
+  'flex-[1_0_100%]',
+  'flex-[0_0_auto]',
+  'flex-[1_1_1/2]',
+  'flex-[1_auto]',
   'flex-[fit-content]',
   'flex',
   'flex-row',


### PR DESCRIPTION
When flex was originally implemented, it was particularly inconvenient, The basis attribute often needs to be customized，Can't do the existing functions，So I am here to ！

![image](https://user-images.githubusercontent.com/39750199/147327946-3db4c915-c5e2-408f-867e-a3ae467e7174.png)

![image](https://user-images.githubusercontent.com/39750199/147328037-f0816cae-8f4b-4a66-b2ac-ed244fe836c4.png)

![image](https://user-images.githubusercontent.com/39750199/147328068-ed9e68fb-91ff-4630-8fbe-310841c2c248.png)

> The picture above is the current problem


**The following is after I added new features**

![image](https://user-images.githubusercontent.com/39750199/147328611-775598dc-f0e4-4647-8a65-145fb9843c1d.png)

![image](https://user-images.githubusercontent.com/39750199/147328627-d19ac27f-4623-40bc-8c33-84bcce5d34d8.png)

**This is specifically compatible with other width types (such as the fit-content in the figure above)**

Can also support x/x writing


