### PR TITLE
feat!: change second arguement of variants to context

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -61,6 +61,11 @@ export function resolveConfig(
     config.theme || {},
   ].reduce((a, p) => mergeDeep(a, p), {})
 
+  const options = Object.assign({}, ...config.presets
+    ?.map(p => Array.isArray(p) ? p : [p])
+    .flat(1)
+    .map(p => p.options ?? {}) || [])
+
   return {
     mergeSelectors: true,
     warn: true,
@@ -80,5 +85,6 @@ export function resolveConfig(
     variants: mergePresets('variants').map(normalizeVariant),
     shortcuts: resolveShortcuts(mergePresets('shortcuts')),
     extractors,
+    options,
   }
 }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -37,6 +37,8 @@ export type ParsedColorValue = {
   rgba?: RGBAColorValue
 }
 
+export type PresetOptions = Record<string, any>
+
 export interface RuleContext<Theme extends {} = {}> {
   /**
    * Unprocessed selector from user input.
@@ -64,12 +66,36 @@ export interface RuleContext<Theme extends {} = {}> {
    * Variants and selector escaping will be handled automatically.
    */
   constructCSS: (body: CSSEntries | CSSObject, overrideSelector?: string) => string
+  /**
+   * User-provided options from preset.
+   */
+  readonly options: PresetOptions
+}
+
+export interface VariantContext<Theme extends {} = {}> {
+  /**
+   * Unprocessed selector from user input.
+   */
+  rawSelector: string
+  /**
+   * UnoCSS generator instance
+   */
+  generator: UnoGenerator
+  /**
+   * The theme object
+   */
+  theme: Theme
+  /**
+   * User-provided options from preset.
+   */
+  readonly options: PresetOptions
 }
 
 export interface ExtractorContext {
   readonly original: string
   code: string
   id?: string
+  readonly options: PresetOptions
 }
 
 export interface Extractor {
@@ -134,7 +160,7 @@ export interface VariantHandler {
   parent?: string | [string, number] | undefined
 }
 
-export type VariantFunction<Theme extends {} = {}> = (matcher: string, raw: string, theme: Theme) => string | VariantHandler | undefined
+export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => string | VariantHandler | undefined
 
 export type VariantObject<Theme extends {} = {}> = {
   /**
@@ -303,6 +329,7 @@ RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'l
   rulesSize: number
   rulesDynamic: (DynamicRule|undefined)[]
   rulesStaticMap: Record<string, [number, CSSObject | CSSEntries, RuleMeta | undefined] | undefined>
+  options: PresetOptions
 }
 
 export interface GenerateResult {

--- a/packages/core/src/utils/basic.ts
+++ b/packages/core/src/utils/basic.ts
@@ -10,3 +10,16 @@ export function mergeSet<T>(target: Set<T>, append: Set<T>): Set<T> {
   append.forEach(i => target.add(i))
   return target
 }
+
+export function cacheFunction<
+  T extends(str: string) => R,
+  R extends string | {
+    readonly [key: string]: string | number
+  }
+>(fn: T): T {
+  const cache: Record<string, R> = Object.create(null)
+  return ((str: string) => {
+    const hit = cache[str]
+    return hit || (cache[str] = fn(str))
+  }) as any
+}

--- a/packages/preset-attributify/src/extractor.ts
+++ b/packages/preset-attributify/src/extractor.ts
@@ -1,6 +1,5 @@
 import type { Extractor } from '@unocss/core'
 import { isValidSelector } from '@unocss/core'
-import type { AttributifyOptions } from '.'
 
 const strippedPrefixes = [
   'v-bind:',
@@ -11,13 +10,13 @@ const splitterRE = /[\s'"`;]+/g
 const elementRE = /<\w[\w:\.$-]*\s((?:'[\s\S]*?'|"[\s\S]*?"|`[\s\S]*?`|\{[\s\S]*?\}|[\s\S]*?)*?)>/g
 const valuedAttributeRE = /([?]|(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:%-]+)(?:=(["'])([^\2]*?)\2)?/g
 
-export const extractorAttributify = (options?: AttributifyOptions): Extractor => ({
+export const extractorAttributify: Extractor = {
   name: 'attributify',
-  extract({ code }) {
+  extract({ code, options: { ignoreAttributes, nonValuedAttribute } }) {
     const result = Array.from(code.matchAll(elementRE))
       .flatMap(match => Array.from((match[1] || '').matchAll(valuedAttributeRE)))
       .flatMap(([, name, _, content]) => {
-        if (options?.ignoreAttributes?.includes(name))
+        if (ignoreAttributes?.includes(name))
           return []
 
         for (const prefix of strippedPrefixes) {
@@ -28,7 +27,7 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
         }
 
         if (!content) {
-          if (isValidSelector(name) && options?.nonValuedAttribute !== false)
+          if (isValidSelector(name) && nonValuedAttribute !== false)
             return [`[${name}=""]`]
           return []
         }
@@ -48,4 +47,4 @@ export const extractorAttributify = (options?: AttributifyOptions): Extractor =>
 
     return new Set(result)
   },
-})
+}

--- a/packages/preset-attributify/src/index.ts
+++ b/packages/preset-attributify/src/index.ts
@@ -8,15 +8,21 @@ export * from './extractor'
 export * from './variant'
 export * from './types'
 
-const preset = (options?: AttributifyOptions): Preset => {
+const preset = (options: AttributifyOptions = {}): Preset => {
+  options.strict = options.strict ?? false
+  options.prefix = options.prefix ?? 'un-'
+  options.prefixedOnly = options.prefixedOnly ?? false
+  options.nonValuedAttribute = options.nonValuedAttribute ?? true
+  options.ignoreAttributes = options.ignoreAttributes ?? []
+
   const variants = [
-    variantAttributify(options),
+    variantAttributify,
   ]
   const extractors = [
-    extractorAttributify(options),
+    extractorAttributify,
   ]
 
-  if (!options?.strict)
+  if (!options.strict)
     extractors.unshift(extractorSplit)
 
   return {

--- a/packages/preset-attributify/src/types.ts
+++ b/packages/preset-attributify/src/types.ts
@@ -1,4 +1,6 @@
-export interface AttributifyOptions {
+import type { PresetOptions } from '@unocss/core'
+
+export interface AttributifyOptions extends PresetOptions {
   /**
    * Only generate CSS for attributify or class
    *

--- a/packages/preset-attributify/src/variants/attributify.ts
+++ b/packages/preset-attributify/src/variants/attributify.ts
@@ -1,28 +1,23 @@
 import type { VariantFunction } from '@unocss/core'
 import { isAttributifySelector } from '@unocss/core'
-import type { AttributifyOptions } from '../types'
 
 const variantsRE = /^(.+\:\!?)?(.*?)$/
 
-export const variantAttributify = (options: AttributifyOptions = {}): VariantFunction => {
-  const prefix = options.prefix ?? 'un-'
+export const variantAttributify: VariantFunction = (input, { options: { prefix, prefixedOnly } }) => {
+  const match = isAttributifySelector(input)
+  if (!match)
+    return
 
-  return (input) => {
-    const match = isAttributifySelector(input)
-    if (!match)
-      return
+  let name = match[1]
+  if (name.startsWith(prefix))
+    name = name.slice(prefix.length)
+  else if (prefixedOnly)
+    return
 
-    let name = match[1]
-    if (name.startsWith(prefix))
-      name = name.slice(prefix.length)
-    else if (options.prefixedOnly)
-      return
-
-    const content = match[2]
-    const [, variants = '', body = content] = content.match(variantsRE) || []
-    if (body === '~' || !body)
-      return `${variants}${name}`
-    else
-      return `${variants}${name}-${body}`
-  }
+  const content = match[2]
+  const [, variants = '', body = content] = content.match(variantsRE) || []
+  if (body === '~' || !body)
+    return `${variants}${name}`
+  else
+    return `${variants}${name}-${body}`
 }

--- a/packages/preset-mini/src/index.ts
+++ b/packages/preset-mini/src/index.ts
@@ -17,11 +17,16 @@ export interface PresetMiniOptions extends PresetOptions {
    * @default false
    */
   attributifyPseudo?: Boolean
+  /**
+   * @default 'un-'
+   */
+  variablePrefix?: string
 }
 
 export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => {
   options.dark = options.dark ?? 'class'
   options.attributifyPseudo = options.attributifyPseudo ?? false
+  options.variablePrefix = options.variablePrefix ?? 'un-'
 
   return {
     name: '@unocss/preset-mini',

--- a/packages/preset-mini/src/index.ts
+++ b/packages/preset-mini/src/index.ts
@@ -1,4 +1,4 @@
-import type { Preset } from '@unocss/core'
+import type { Preset, PresetOptions } from '@unocss/core'
 import { rules } from './rules'
 import type { Theme, ThemeAnimation } from './theme'
 import { theme } from './theme'
@@ -8,7 +8,7 @@ export { theme, colors } from './theme'
 
 export type { ThemeAnimation, Theme }
 
-export interface PresetMiniOptions {
+export interface PresetMiniOptions extends PresetOptions {
   /**
    * @default 'class'
    */
@@ -19,12 +19,17 @@ export interface PresetMiniOptions {
   attributifyPseudo?: Boolean
 }
 
-export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => ({
-  name: '@unocss/preset-mini',
-  theme,
-  rules,
-  variants: variants(options),
-  options,
-})
+export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => {
+  options.dark = options.dark ?? 'class'
+  options.attributifyPseudo = options.attributifyPseudo ?? false
+
+  return {
+    name: '@unocss/preset-mini',
+    theme,
+    rules,
+    variants,
+    options,
+  }
+}
 
 export default presetMini

--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -13,12 +13,12 @@ export const borders: Rule[] = [
   // colors
   [/^(?:border|b)()-(.+)$/, handlerBorderColor],
   [/^(?:border|b)-([^-]+)(?:-(.+))?$/, handlerBorderColor],
-  [/^(?:border|b)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-border-opacity': h.bracket.percent(opacity) })],
-  [/^(?:border|b)-([^-]+)-op(?:acity)?-?(.+)$/, ([, a, opacity]) => {
+  [/^(?:border|b)-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}border-opacity`]: h.bracket.percent(opacity) })],
+  [/^(?:border|b)-([^-]+)-op(?:acity)?-?(.+)$/, ([, a, opacity], { options: { variablePrefix: p } }) => {
     const v = h.bracket.percent(opacity)
     const d = directionMap[a]
     if (v !== undefined && d)
-      return d.map(i => [`--un-border${i}-opacity`, v]) as CSSEntries
+      return d.map(i => [`--${p}border${i}-opacity`, v]) as CSSEntries
   }],
 
   // radius
@@ -38,7 +38,7 @@ const borderHasColor = (color: string, { theme }: RuleContext<Theme>) => {
   return color !== undefined && !!parseColor(color, theme)?.color
 }
 
-const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined => {
+const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: string[], { theme, options: { variablePrefix: p } }): CSSObject | undefined => {
   const data = parseColor(body, theme)
 
   if (!data)
@@ -68,15 +68,15 @@ const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: st
     else {
       if (direction === '') {
         return {
-          '--un-border-opacity': 1,
-          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--un-border${direction}-opacity))`,
+          [`--${p}border-opacity`]: 1,
+          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--${p}border${direction}-opacity))`,
         }
       }
       else {
         return {
-          '--un-border-opacity': 1,
-          [`--un-border${direction}-opacity`]: 'var(--un-border-opacity)',
-          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--un-border${direction}-opacity))`,
+          [`--${p}border-opacity`]: 1,
+          [`--${p}border${direction}-opacity`]: `var(--${p}border-opacity)`,
+          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--${p}border${direction}-opacity))`,
         }
       }
     }

--- a/packages/preset-mini/src/rules/ring.ts
+++ b/packages/preset-mini/src/rules/ring.ts
@@ -1,42 +1,38 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
 import { colorResolver, handler as h } from '../utils'
-import { varEmpty } from './static'
+import { varEmptyFn } from './static'
 
 export const rings: Rule<Theme>[] = [
   // size
-  [/^ring-?(.*)$/, ([, d]) => {
+  [/^ring-?(.*)$/, ([, d], { options: { variablePrefix: p } }) => {
     const value = h.px(d || '1')
     if (value) {
       return {
-        '--un-ring-inset': varEmpty,
-        '--un-ring-offset-width': '0px',
-        '--un-ring-offset-color': '#fff',
-        '--un-ring-color': 'rgba(59, 130, 246, .5)',
-        '--un-ring-offset-shadow': 'var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color)',
-        '--un-ring-shadow': `var(--un-ring-inset) 0 0 0 calc(${value} + var(--un-ring-offset-width)) var(--un-ring-color)`,
-        '-webkit-box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
-        'box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
+        [`--${p}ring-inset`]: varEmptyFn(p),
+        [`--${p}ring-offset-width`]: '0px',
+        [`--${p}ring-offset-color`]: '#fff',
+        [`--${p}ring-color`]: 'rgba(59, 130, 246, .5)',
+        [`--${p}ring-offset-shadow`]: `var(--${p}ring-inset) 0 0 0 var(--${p}ring-offset-width) var(--${p}ring-offset-color)`,
+        [`--${p}ring-shadow`]: `var(--${p}ring-inset) 0 0 0 calc(${value} + var(--${p}ring-offset-width)) var(--${p}ring-color)`,
+        '-webkit-box-shadow': `var(--${p}ring-offset-shadow), var(--${p}ring-shadow), var(--${p}shadow, 0 0 #0000)`,
+        'box-shadow': `var(--${p}ring-offset-shadow), var(--${p}ring-shadow), var(--${p}shadow, 0 0 #0000)`,
       }
     }
   }],
 
   // offset size
-  ['ring-offset', { '--un-ring-offset-width': '1px' }],
-  [/^ring-offset-(.+)$/, ([, d]) => {
-    const value = h.px(d || '1')
-    if (value)
-      return { '--un-ring-offset-width': value }
-  }],
+  [/^ring-offset$/, (_, { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-width`]: '1px' })],
+  [/^ring-offset-(.+)$/, ([, d], { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-width`]: h.px(d || '1') })],
 
   // colors
-  [/^ring-(.+)$/, colorResolver('--un-ring-color', 'ring')],
-  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-opacity': h.bracket.percent(opacity) })],
+  [/^ring-(.+)$/, (m, ctx) => colorResolver(`--${ctx.options.variablePrefix}ring-color`, 'ring')(m, ctx)],
+  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}ring-opacity`]: h.bracket.percent(opacity) })],
 
   // offset color
-  [/^ring-offset-(.+)$/, colorResolver('--un-ring-offset-color', 'ring-offset')],
-  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-offset-opacity': h.bracket.percent(opacity) })],
+  [/^ring-offset-(.+)$/, (m, ctx) => colorResolver(`--${ctx.options.variablePrefix}ring-offset-color`, 'ring-offset')(m, ctx)],
+  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-opacity`]: h.bracket.percent(opacity) })],
 
   // style
-  ['ring-inset', { '--un-ring-inset': 'inset' }],
+  [/^ring-inset$/, (_, { options: { variablePrefix: p } }) => ({ [`--${p}ring-inset`]: 'inset' })],
 ]

--- a/packages/preset-mini/src/rules/static.ts
+++ b/packages/preset-mini/src/rules/static.ts
@@ -1,4 +1,7 @@
 import type { Rule } from '@unocss/core'
+import { cacheFunction } from '@unocss/core'
+
+export const varEmptyFn = cacheFunction((prefix: string) => `var(--${prefix}empty,/*!*/ /*!*/)`)
 
 export const varEmpty = 'var(--un-empty,/*!*/ /*!*/)'
 

--- a/packages/preset-mini/src/variants/breakpoints.ts
+++ b/packages/preset-mini/src/variants/breakpoints.ts
@@ -3,7 +3,7 @@ import type { Theme } from '../theme'
 
 const regexCache: Record<string, RegExp> = {}
 
-export const variantBreakpoints: Variant<Theme> = (matcher, _, theme) => {
+export const variantBreakpoints: Variant<Theme> = (matcher, { theme }) => {
   const variantEntries: Array<[string, string, number]>
       = Object.entries(theme.breakpoints || {}).map(([point, size], idx) => [point, size, idx])
   for (const [point, size, idx] of variantEntries) {

--- a/packages/preset-mini/src/variants/dark.ts
+++ b/packages/preset-mini/src/variants/dark.ts
@@ -1,25 +1,40 @@
 import type { Variant } from '@unocss/core'
 import { variantMatcher } from '../utils'
 
-export const variantColorsClass: Variant[] = [
-  variantMatcher('dark', input => `.dark $$ ${input}`),
-  variantMatcher('light', input => `.light $$ ${input}`),
-]
-
-export const variantColorsMedia: Variant[] = [
-  (v) => {
-    const dark = variantMatcher('dark')(v)
-    if (dark) {
-      return {
-        ...dark,
-        parent: '@media (prefers-color-scheme: dark)',
+export const variantColorsMediaOrClass: Variant[] = [
+  (v, { options: { dark } }) => {
+    if (dark === 'class') {
+      const match = variantMatcher('dark', input => `.dark $$ ${input}`)(v)
+      if (match)
+        return match
+    }
+  },
+  (v, { options: { dark } }) => {
+    if (dark === 'class') {
+      const match = variantMatcher('light', input => `.light $$ ${input}`)(v)
+      if (match)
+        return match
+    }
+  },
+  (v, { options: { dark } }) => {
+    if (dark === 'media') {
+      const match = variantMatcher('dark')(v)
+      if (match) {
+        return {
+          ...match,
+          parent: '@media (prefers-color-scheme: dark)',
+        }
       }
     }
-    const light = variantMatcher('light')(v)
-    if (light) {
-      return {
-        ...light,
-        parent: '@media (prefers-color-scheme: light)',
+  },
+  (v, { options: { dark } }) => {
+    if (dark === 'media') {
+      const match = variantMatcher('light')(v)
+      if (match) {
+        return {
+          ...match,
+          parent: '@media (prefers-color-scheme: light)',
+        }
       }
     }
   },

--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -1,13 +1,12 @@
 import type { Variant } from '@unocss/core'
-import type { PresetMiniOptions } from '..'
 import type { Theme } from '../theme'
 import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
-import { variantColorsClass, variantColorsMedia } from './dark'
+import { variantColorsMediaOrClass } from './dark'
 import { variantImportant, variantNegative, variantSpace } from './misc'
 import { partClasses, variantPseudoClassFunctions, variantPseudoClasses, variantPseudoElements, variantTaggedPseudoClasses } from './pseudo'
 
-export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
+export const variants: Variant<Theme>[] = [
   variantSpace,
   variantNegative,
   variantImportant,
@@ -15,10 +14,8 @@ export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
   ...variantCombinators,
   variantPseudoClasses,
   variantPseudoClassFunctions,
-  variantTaggedPseudoClasses(options),
+  variantTaggedPseudoClasses,
   variantPseudoElements,
   partClasses,
-  ...options.dark === 'media'
-    ? variantColorsMedia
-    : variantColorsClass,
+  ...variantColorsMediaOrClass,
 ]

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -1,6 +1,5 @@
 import type { CSSEntries, VariantFunction, VariantHandler, VariantObject } from '@unocss/core'
 import { escapeRegExp, toArray } from '@unocss/core'
-import type { PresetMiniOptions } from '..'
 
 export const CONTROL_BYPASS_PSEUDO_CLASS = '$$no-pseudo'
 
@@ -137,15 +136,13 @@ export const variantPseudoClassFunctions: VariantObject = {
   multiPass: true,
 }
 
-export const variantTaggedPseudoClasses = (options: PresetMiniOptions = {}): VariantObject => ({
-  match: (input: string) => {
-    const attributify = !!options?.attributifyPseudo
-
-    const g = taggedPseudoClassMatcher('group', attributify ? '[group=""]' : '.group', ' ')(input)
+export const variantTaggedPseudoClasses: VariantObject = ({
+  match: (input, { options: { attributifyPseudo } }) => {
+    const g = taggedPseudoClassMatcher('group', attributifyPseudo ? '[group=""]' : '.group', ' ')(input)
     if (g)
       return g
 
-    const p = taggedPseudoClassMatcher('peer', attributify ? '[peer=""]' : '.peer', '~')(input)
+    const p = taggedPseudoClassMatcher('peer', attributifyPseudo ? '[peer=""]' : '.peer', '~')(input)
     if (p)
       return p
   },

--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -17,6 +17,7 @@ export interface UnoOptions extends PresetMiniOptions { }
 export const presetWind = (options: UnoOptions = {}): Preset<Theme> => {
   options.dark = options.dark ?? 'class'
   options.attributifyPseudo = options.attributifyPseudo ?? false
+  options.variablePrefix = options.variablePrefix ?? 'un-'
 
   return {
     name: '@unocss/preset-wind',

--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -1,5 +1,5 @@
 import type { Preset } from '@unocss/core'
-import type { Theme } from '@unocss/preset-mini'
+import type { PresetMiniOptions, Theme } from '@unocss/preset-mini'
 import { variants } from '@unocss/preset-mini/variants'
 import { rules } from './rules'
 import { containerShortcuts } from './rules/container'
@@ -12,29 +12,25 @@ export type { Theme } from '@unocss/preset-mini'
 
 export { theme }
 
-export interface UnoOptions {
-  /**
-   * @default 'class'
-   */
-  dark?: 'class' | 'media'
-  /**
-   * @default false
-   */
-  attributifyPseudo?: Boolean
-}
+export interface UnoOptions extends PresetMiniOptions { }
 
-export const presetWind = (options: UnoOptions = {}): Preset<Theme> => ({
-  name: '@unocss/preset-wind',
-  theme,
-  rules,
-  shortcuts: [
-    ...containerShortcuts,
-  ],
-  variants: [
-    ...variants(options),
-    ...variantColorsScheme,
-  ],
-  options,
-})
+export const presetWind = (options: UnoOptions = {}): Preset<Theme> => {
+  options.dark = options.dark ?? 'class'
+  options.attributifyPseudo = options.attributifyPseudo ?? false
+
+  return {
+    name: '@unocss/preset-wind',
+    theme,
+    rules,
+    shortcuts: [
+      ...containerShortcuts,
+    ],
+    variants: [
+      ...variants,
+      ...variantColorsScheme,
+    ],
+    options,
+  }
+}
 
 export default presetWind

--- a/packages/preset-wind/src/variants/dark.ts
+++ b/packages/preset-wind/src/variants/dark.ts
@@ -6,17 +6,19 @@ export const variantColorsScheme: Variant[] = [
   variantMatcher('\\.light', input => `.light $$ ${input}`),
 
   (v) => {
-    const dark = variantMatcher('@dark')(v)
-    if (dark) {
+    const match = variantMatcher('@dark')(v)
+    if (match) {
       return {
-        ...dark,
+        ...match,
         parent: '@media (prefers-color-scheme: dark)',
       }
     }
-    const light = variantMatcher('@light')(v)
-    if (light) {
+  },
+  (v) => {
+    const match = variantMatcher('@light')(v)
+    if (match) {
       return {
-        ...light,
+        ...match,
         parent: '@media (prefers-color-scheme: light)',
       }
     }

--- a/test/preset-attributify.test.ts
+++ b/test/preset-attributify.test.ts
@@ -80,10 +80,19 @@ describe('attributify', () => {
   })
 
   test('variant', async() => {
-    const variant = variantAttributify()
     expect(Array.from(await uno.applyExtractors(fixture1) || [])
       .map((i) => {
-        const r = variant(i, i, {} as any)
+        const r = variantAttributify(i, {
+          generator: uno,
+          options: {
+            prefix: 'un-',
+            prefixedOnly: false,
+            strict: true,
+          },
+          rawSelector: i,
+          theme: {},
+        })
+
         return typeof r === 'string' ? r : r ? r.matcher : r
       }))
       .toMatchSnapshot()


### PR DESCRIPTION
PR is for #303.

Two commits. The first one refactor core to merge presets options and prepare it as part of `context` variable in callback. This in consequece also need refactors on the related presets.

The second commit is an example use on border and ring, due to heavy use of css variable on them.

The drawback with this feature is most static rules that use css variable will get converted to regex with exact match to get the prefix option in the callback.
