### PR TITLE
fix(preset-mini)!: revert initial support for css variable prefix

### DIFF
--- a/packages/core/src/utils/basic.ts
+++ b/packages/core/src/utils/basic.ts
@@ -10,16 +10,3 @@ export function mergeSet<T>(target: Set<T>, append: Set<T>): Set<T> {
   append.forEach(i => target.add(i))
   return target
 }
-
-export function cacheFunction<
-  T extends(str: string) => R,
-  R extends string | {
-    readonly [key: string]: string | number
-  }
->(fn: T): T {
-  const cache: Record<string, R> = Object.create(null)
-  return ((str: string) => {
-    const hit = cache[str]
-    return hit || (cache[str] = fn(str))
-  }) as any
-}

--- a/packages/preset-mini/src/index.ts
+++ b/packages/preset-mini/src/index.ts
@@ -17,16 +17,11 @@ export interface PresetMiniOptions extends PresetOptions {
    * @default false
    */
   attributifyPseudo?: Boolean
-  /**
-   * @default 'un-'
-   */
-  variablePrefix?: string
 }
 
 export const presetMini = (options: PresetMiniOptions = {}): Preset<Theme> => {
   options.dark = options.dark ?? 'class'
   options.attributifyPseudo = options.attributifyPseudo ?? false
-  options.variablePrefix = options.variablePrefix ?? 'un-'
 
   return {
     name: '@unocss/preset-mini',

--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -13,12 +13,12 @@ export const borders: Rule[] = [
   // colors
   [/^(?:border|b)()-(.+)$/, handlerBorderColor],
   [/^(?:border|b)-([^-]+)(?:-(.+))?$/, handlerBorderColor],
-  [/^(?:border|b)-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}border-opacity`]: h.bracket.percent(opacity) })],
-  [/^(?:border|b)-([^-]+)-op(?:acity)?-?(.+)$/, ([, a, opacity], { options: { variablePrefix: p } }) => {
+  [/^(?:border|b)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-border-opacity': h.bracket.percent(opacity) })],
+  [/^(?:border|b)-([^-]+)-op(?:acity)?-?(.+)$/, ([, a, opacity]) => {
     const v = h.bracket.percent(opacity)
     const d = directionMap[a]
     if (v !== undefined && d)
-      return d.map(i => [`--${p}border${i}-opacity`, v]) as CSSEntries
+      return d.map(i => [`--un-border${i}-opacity`, v]) as CSSEntries
   }],
 
   // radius
@@ -38,7 +38,7 @@ const borderHasColor = (color: string, { theme }: RuleContext<Theme>) => {
   return color !== undefined && !!parseColor(color, theme)?.color
 }
 
-const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: string[], { theme, options: { variablePrefix: p } }): CSSObject | undefined => {
+const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: string[], { theme }: RuleContext<Theme>): CSSObject | undefined => {
   const data = parseColor(body, theme)
 
   if (!data)
@@ -68,15 +68,15 @@ const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: st
     else {
       if (direction === '') {
         return {
-          [`--${p}border-opacity`]: 1,
-          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--${p}border${direction}-opacity))`,
+          '--un-border-opacity': 1,
+          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--un-border${direction}-opacity))`,
         }
       }
       else {
         return {
-          [`--${p}border-opacity`]: 1,
-          [`--${p}border${direction}-opacity`]: `var(--${p}border-opacity)`,
-          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--${p}border${direction}-opacity))`,
+          '--un-border-opacity': 1,
+          [`--un-border${direction}-opacity`]: 'var(--un-border-opacity)',
+          [`border${direction}-color`]: `rgba(${rgba.slice(0, 3).join(',')},var(--un-border${direction}-opacity))`,
         }
       }
     }

--- a/packages/preset-mini/src/rules/ring.ts
+++ b/packages/preset-mini/src/rules/ring.ts
@@ -1,38 +1,42 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
 import { colorResolver, handler as h } from '../utils'
-import { varEmptyFn } from './static'
+import { varEmpty } from './static'
 
 export const rings: Rule<Theme>[] = [
   // size
-  [/^ring-?(.*)$/, ([, d], { options: { variablePrefix: p } }) => {
+  [/^ring-?(.*)$/, ([, d]) => {
     const value = h.px(d || '1')
     if (value) {
       return {
-        [`--${p}ring-inset`]: varEmptyFn(p),
-        [`--${p}ring-offset-width`]: '0px',
-        [`--${p}ring-offset-color`]: '#fff',
-        [`--${p}ring-color`]: 'rgba(59, 130, 246, .5)',
-        [`--${p}ring-offset-shadow`]: `var(--${p}ring-inset) 0 0 0 var(--${p}ring-offset-width) var(--${p}ring-offset-color)`,
-        [`--${p}ring-shadow`]: `var(--${p}ring-inset) 0 0 0 calc(${value} + var(--${p}ring-offset-width)) var(--${p}ring-color)`,
-        '-webkit-box-shadow': `var(--${p}ring-offset-shadow), var(--${p}ring-shadow), var(--${p}shadow, 0 0 #0000)`,
-        'box-shadow': `var(--${p}ring-offset-shadow), var(--${p}ring-shadow), var(--${p}shadow, 0 0 #0000)`,
+        '--un-ring-inset': varEmpty,
+        '--un-ring-offset-width': '0px',
+        '--un-ring-offset-color': '#fff',
+        '--un-ring-color': 'rgba(59, 130, 246, .5)',
+        '--un-ring-offset-shadow': 'var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color)',
+        '--un-ring-shadow': `var(--un-ring-inset) 0 0 0 calc(${value} + var(--un-ring-offset-width)) var(--un-ring-color)`,
+        '-webkit-box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
+        'box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
       }
     }
   }],
 
   // offset size
-  [/^ring-offset$/, (_, { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-width`]: '1px' })],
-  [/^ring-offset-(.+)$/, ([, d], { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-width`]: h.px(d || '1') })],
+  ['ring-offset', { '--un-ring-offset-width': '1px' }],
+  [/^ring-offset-(.+)$/, ([, d]) => {
+    const value = h.px(d || '1')
+    if (value)
+      return { '--un-ring-offset-width': value }
+  }],
 
   // colors
-  [/^ring-(.+)$/, (m, ctx) => colorResolver(`--${ctx.options.variablePrefix}ring-color`, 'ring')(m, ctx)],
-  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}ring-opacity`]: h.bracket.percent(opacity) })],
+  [/^ring-(.+)$/, colorResolver('--un-ring-color', 'ring')],
+  [/^ring-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-opacity': h.bracket.percent(opacity) })],
 
   // offset color
-  [/^ring-offset-(.+)$/, (m, ctx) => colorResolver(`--${ctx.options.variablePrefix}ring-offset-color`, 'ring-offset')(m, ctx)],
-  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity], { options: { variablePrefix: p } }) => ({ [`--${p}ring-offset-opacity`]: h.bracket.percent(opacity) })],
+  [/^ring-offset-(.+)$/, colorResolver('--un-ring-offset-color', 'ring-offset')],
+  [/^ring-offset-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-ring-offset-opacity': h.bracket.percent(opacity) })],
 
   // style
-  [/^ring-inset$/, (_, { options: { variablePrefix: p } }) => ({ [`--${p}ring-inset`]: 'inset' })],
+  ['ring-inset', { '--un-ring-inset': 'inset' }],
 ]

--- a/packages/preset-mini/src/rules/static.ts
+++ b/packages/preset-mini/src/rules/static.ts
@@ -1,7 +1,4 @@
 import type { Rule } from '@unocss/core'
-import { cacheFunction } from '@unocss/core'
-
-export const varEmptyFn = cacheFunction((prefix: string) => `var(--${prefix}empty,/*!*/ /*!*/)`)
 
 export const varEmpty = 'var(--un-empty,/*!*/ /*!*/)'
 

--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -17,7 +17,6 @@ export interface UnoOptions extends PresetMiniOptions { }
 export const presetWind = (options: UnoOptions = {}): Preset<Theme> => {
   options.dark = options.dark ?? 'class'
   options.attributifyPseudo = options.attributifyPseudo ?? false
-  options.variablePrefix = options.variablePrefix ?? 'un-'
 
   return {
     name: '@unocss/preset-wind',


### PR DESCRIPTION
Reverts 2nd commit of #321:

https://github.com/antfu/unocss/pull/321/commits/da64b953d8d30630fa1f7318d1b8620a51f2760a