### PR TITLE
feat(core)!: callbacks for altering how css is generated

### DIFF
--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -72,6 +72,8 @@ export function resolveConfig(
     blocklist: [],
     safelist: [],
     sortLayers: layers => layers,
+    serializeEntry: (key, value) => `${key}:${value};`,
+    prepareLayer: css => css,
     ...config,
     presets: sortedPresets,
     envMode: config.envMode || 'build',

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -205,7 +205,7 @@ export class UnoGenerator {
           .join(nl)
       }
 
-      css = this.config.prepareLayer(css, layer, this.config.options)
+      css = this.config.prepareLayer(css, layer)
 
       return layerCache[layer] = !minify && css
         ? `/* layer: ${layer} */${nl}${css}`

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -205,6 +205,8 @@ export class UnoGenerator {
           .join(nl)
       }
 
+      css = this.config.prepareLayer(css, layer, this.config.options)
+
       return layerCache[layer] = !minify && css
         ? `/* layer: ${layer} */${nl}${css}`
         : css
@@ -286,7 +288,7 @@ export class UnoGenerator {
     body = normalizeCSSEntries(body)
 
     const [selector, entries, mediaQuery] = this.applyVariants([0, overrideSelector || context.rawSelector, body, undefined, context.variantHandlers])
-    const cssBody = `${selector}{${entriesToCss(entries)}}`
+    const cssBody = `${selector}{${entriesToCss(entries, this.config.serializeEntry)}}`
     if (mediaQuery)
       return `${mediaQuery}{${cssBody}}`
     return cssBody
@@ -346,7 +348,7 @@ export class UnoGenerator {
       return [parsed[0], undefined, parsed[1], undefined, parsed[2]]
 
     const [selector, entries, mediaQuery] = this.applyVariants(parsed)
-    const body = entriesToCss(entries)
+    const body = entriesToCss(entries, this.config.serializeEntry)
 
     if (!body)
       return
@@ -432,7 +434,7 @@ export class UnoGenerator {
 
     return selectorMap
       .map(([entries, index], selector, mediaQuery): StringifiedUtil | undefined => {
-        const body = entriesToCss(entries)
+        const body = entriesToCss(entries, this.config.serializeEntry)
         if (body)
           return [index, selector, body, mediaQuery, meta]
         return undefined

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -241,7 +241,7 @@ export interface ConfigBase<Theme extends {} = {}> {
   /**
    * Custom function to alter generated css.
    */
-  prepareLayer?: (css: string, layer: string, options: PresetOptions) => string
+  prepareLayer?: (css: string, layer: string) => string
 }
 
 export interface Preset<Theme extends {} = {}> extends ConfigBase<Theme> {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -232,6 +232,16 @@ export interface ConfigBase<Theme extends {} = {}> {
    * Custom function to sort layers.
    */
   sortLayers?: (layers: string[]) => string[]
+
+  /**
+   * Custom function to serialize css entry {@link CSSEntries}.
+   */
+  serializeEntry?: (key: string, value: string | number) => string
+
+  /**
+   * Custom function to alter generated css.
+   */
+  prepareLayer?: (css: string, layer: string, options: PresetOptions) => string
 }
 
 export interface Preset<Theme extends {} = {}> extends ConfigBase<Theme> {
@@ -321,7 +331,7 @@ export interface UserConfig<Theme extends {} = {}> extends ConfigBase<Theme>, Us
 export interface UserConfigDefaults<Theme extends {} = {}> extends ConfigBase<Theme>, UserOnlyOptions<Theme> {}
 
 export interface ResolvedConfig extends Omit<
-RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
+RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers' | 'serializeEntry' | 'prepareLayer'>,
 'rules' | 'shortcuts'
 > {
   shortcuts: Shortcut[]

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -31,11 +31,11 @@ export function clearIdenticalEntries(entry: CSSEntries): CSSEntries {
   })
 }
 
-export function entriesToCss(arr?: CSSEntries) {
+export function entriesToCss(arr: CSSEntries | undefined, serializer: (key: string, value: string | number) => string) {
   if (arr == null)
     return ''
   return clearIdenticalEntries(arr)
-    .map(([key, value]) => value != null ? `${key}:${value};` : undefined)
+    .map(([key, value]) => value != null ? serializer(key, value) : undefined)
     .filter(Boolean)
     .join('')
 }


### PR DESCRIPTION
Sample use on preset-mini:

```js
const uno = createGenerator({
  serializeEntry: (k, v) => `${k.replace(/^--un-/, '--css-uno-')}:${`${v}`.replace(/(\bvar\(--un-)/g, 'var(--css-uno-')};`,
  presets: [
```

![image](https://user-images.githubusercontent.com/379924/147520507-202e2ac6-e069-4443-99ef-356c7ba72168.png)

Modifying raw rule needs to be done on the whole layer with `prepareLayer`. I'm not sure how easy it can be, so I'll take it out if you think it is not necessary.
