### PR TITLE
refactor(core)!: update `CSSValues` and `CSSEntries` types

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,6 +1,6 @@
 import type { CSSEntry, CSSObject, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, RawUtil, ResolvedConfig, RuleContext, RuleMeta, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantMatchedResult } from '../types'
 import { resolveConfig } from '../config'
-import { TwoKeyMap, e, entriesToCss, expandVariantGroup, isRawUtil, isStaticShortcut, normalizeCSSEntries, normalizeCSSValues, notNull, uniq, warnOnce } from '../utils'
+import { TwoKeyMap, e, entriesToCss, expandVariantGroup, isRawUtil, isStaticShortcut, normalizeCSSValue, normalizeCSSValues, notNull, uniq, warnOnce } from '../utils'
 import { version } from '../../package.json'
 
 export class UnoGenerator {
@@ -292,7 +292,7 @@ export class UnoGenerator {
   }
 
   constructCustomCSS(context: Readonly<RuleContext>, body: CSSObject | CSSEntry[], overrideSelector?: string) {
-    body = normalizeCSSEntries(body)
+    body = normalizeCSSValue(body)
 
     const { selector, entries, parent } = this.applyVariants([0, overrideSelector || context.rawSelector, body, undefined, context.variantHandlers])
     const cssBody = `${selector}{${entriesToCss(entries)}}`
@@ -310,7 +310,7 @@ export class UnoGenerator {
     const staticMatch = this.config.rulesStaticMap[processed]
     if (staticMatch) {
       if (staticMatch[1] && (internal || !staticMatch[2]?.internal))
-        return [[staticMatch[0], raw, normalizeCSSEntries(staticMatch[1]), staticMatch[2], variantHandlers]]
+        return [[staticMatch[0], raw, normalizeCSSValue(staticMatch[1]), staticMatch[2], variantHandlers]]
     }
 
     context.variantHandlers = variantHandlers

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, CSSObject, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, RawUtil, ResolvedConfig, RuleContext, RuleMeta, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantMatchedResult } from '../types'
+import type { CSSEntry, CSSObject, ExtractorContext, GenerateOptions, GenerateResult, ParsedUtil, RawUtil, ResolvedConfig, RuleContext, RuleMeta, StringifiedUtil, UserConfig, UserConfigDefaults, UtilObject, Variant, VariantContext, VariantHandler, VariantMatchedResult } from '../types'
 import { resolveConfig } from '../config'
 import { TwoKeyMap, e, entriesToCss, expandVariantGroup, isRawUtil, isStaticShortcut, normalizeCSSEntries, normalizeCSSValues, notNull, uniq, warnOnce } from '../utils'
 import { version } from '../../package.json'
@@ -291,7 +291,7 @@ export class UnoGenerator {
     return obj
   }
 
-  constructCustomCSS(context: Readonly<RuleContext>, body: CSSObject | CSSEntries, overrideSelector?: string) {
+  constructCustomCSS(context: Readonly<RuleContext>, body: CSSObject | CSSEntry[], overrideSelector?: string) {
     body = normalizeCSSEntries(body)
 
     const { selector, entries, parent } = this.applyVariants([0, overrideSelector || context.rawSelector, body, undefined, context.variantHandlers])
@@ -408,7 +408,7 @@ export class UnoGenerator {
     expanded: string[],
     meta: RuleMeta = { layer: this.config.shortcutsLayer },
   ): Promise<StringifiedUtil[] | undefined> {
-    const selectorMap = new TwoKeyMap<string, string | undefined, [CSSEntries, number]>()
+    const selectorMap = new TwoKeyMap<string, string | undefined, [CSSEntry[], number]>()
 
     const parsed = (
       await Promise.all(uniq(expanded)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -65,7 +65,7 @@ export interface RuleContext<Theme extends {} = {}> {
    * Constrcut a custom CSS rule.
    * Variants and selector escaping will be handled automatically.
    */
-  constructCSS: (body: CSSEntries | CSSObject, overrideSelector?: string) => string
+  constructCSS: (body: CSSEntry[] | CSSObject, overrideSelector?: string) => string
   /**
    * User-provided options from preset.
    */
@@ -117,11 +117,11 @@ export interface RuleMeta {
   internal?: boolean
 }
 
-export type CSSValues = CSSObject | CSSEntries | (CSSObject | CSSEntries)[]
+export type CSSValues = CSSObject | CSSEntry[] | (CSSObject | CSSEntry[])[]
 
 export type DynamicMatcher<Theme extends {} = {}> = ((match: RegExpMatchArray, context: Readonly<RuleContext<Theme>>) => Awaitable<CSSValues | string | undefined>)
 export type DynamicRule<Theme extends {} = {}> = [RegExp, DynamicMatcher<Theme>] | [RegExp, DynamicMatcher<Theme>, RuleMeta]
-export type StaticRule = [string, CSSObject | CSSEntries] | [string, CSSObject | CSSEntries, RuleMeta]
+export type StaticRule = [string, CSSObject | CSSEntry[]] | [string, CSSObject | CSSEntry[], RuleMeta]
 export type Rule<Theme extends {} = {}> = DynamicRule<Theme> | StaticRule
 
 export type DynamicShortcutMatcher<Theme extends {} = {}> = ((match: RegExpMatchArray, context: Readonly<RuleContext<Theme>>) => (string | string [] | undefined))
@@ -149,11 +149,11 @@ export interface VariantHandler {
   /**
    * Rewrite the output selector. Often be used to append pesudo classes or parents.
    */
-  selector?: (input: string, body: CSSEntries) => string | undefined
+  selector?: (input: string, body: CSSEntry[]) => string | undefined
   /**
    * Rewrite the output css body. The input come in [key,value][] pairs.
    */
-  body?: (body: CSSEntries) => CSSEntries | undefined
+  body?: (body: CSSEntry[]) => CSSEntry[] | undefined
   /**
    * Provide a parent selector(e.g. media query) to the output css.
    */
@@ -338,7 +338,7 @@ RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'l
   postprocess: Postprocessor[]
   rulesSize: number
   rulesDynamic: (DynamicRule|undefined)[]
-  rulesStaticMap: Record<string, [number, CSSObject | CSSEntries, RuleMeta | undefined] | undefined>
+  rulesStaticMap: Record<string, [number, CSSObject | CSSEntry[], RuleMeta | undefined] | undefined>
   options: PresetOptions
 }
 
@@ -359,7 +359,7 @@ export type VariantMatchedResult = readonly [
 export type ParsedUtil = readonly [
   index: number,
   raw: string,
-  entries: CSSEntries,
+  entries: CSSEntry[],
   meta: RuleMeta | undefined,
   variants: VariantHandler[]
 ]
@@ -380,7 +380,7 @@ export type StringifiedUtil = readonly [
 
 export interface UtilObject {
   selector: string
-  entries: CSSEntries
+  entries: CSSEntry[]
   parent: string | undefined
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -117,7 +117,7 @@ export interface RuleMeta {
   internal?: boolean
 }
 
-export type CSSValues = CSSObject | CSSEntry[] | (CSSObject | CSSEntry[])[]
+export type CSSValues = CSSObject | (CSSObject | CSSEntry[])[]
 
 export type DynamicMatcher<Theme extends {} = {}> = ((match: RegExpMatchArray, context: Readonly<RuleContext<Theme>>) => Awaitable<CSSValues | string | undefined>)
 export type DynamicRule<Theme extends {} = {}> = [RegExp, DynamicMatcher<Theme>] | [RegExp, DynamicMatcher<Theme>, RuleMeta]

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -11,7 +11,7 @@ export type PartialByKeys<T, K extends keyof T = keyof T> = FlatObjectTuple<Part
 export type RequiredByKey<T, K extends keyof T = keyof T> = FlatObjectTuple<Required<Pick<T, Extract<keyof T, K>>> & Omit<T, K>>
 
 export type CSSObject = Record<string, string | number | undefined>
-export type CSSEntries = [string, string | number | undefined][]
+export type CSSEntry = [string, string | number | undefined]
 
 export type RGBAColorValue = [number, number, number, number] | [number, number, number]
 export type ParsedColorValue = {

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -1,20 +1,14 @@
 import type { CSSEntry, CSSObject, CSSValues, DeepPartial, Rule, Shortcut, StaticRule, StaticShortcut } from '../types'
 
-export function normalizeCSSEntries(obj: CSSEntry[] | CSSObject): CSSEntry[] {
+export function normalizeCSSValue(obj: CSSEntry[] | CSSObject): CSSEntry[] {
   return (!Array.isArray(obj) ? Object.entries(obj) : obj).filter(i => i[1] != null)
 }
 
 export function normalizeCSSValues(obj: CSSValues): CSSEntry[][] {
-  if (Array.isArray(obj)) {
-    // @ts-expect-error
-    if (obj.find(i => !Array.isArray(i) || Array.isArray(i[0])))
-      return (obj as any).map((i: any) => normalizeCSSEntries(i))
-    else
-      return [obj as any]
-  }
-  else {
-    return [normalizeCSSEntries(obj)]
-  }
+  if (Array.isArray(obj))
+    return obj.map(i => normalizeCSSValue(i))
+
+  return [normalizeCSSValue(obj)]
 }
 
 export function clearIdenticalEntries(entry: CSSEntry[]): CSSEntry[] {

--- a/packages/core/src/utils/object.ts
+++ b/packages/core/src/utils/object.ts
@@ -1,10 +1,10 @@
-import type { CSSEntries, CSSObject, CSSValues, DeepPartial, Rule, Shortcut, StaticRule, StaticShortcut } from '../types'
+import type { CSSEntry, CSSObject, CSSValues, DeepPartial, Rule, Shortcut, StaticRule, StaticShortcut } from '../types'
 
-export function normalizeCSSEntries(obj: CSSEntries | CSSObject): CSSEntries {
+export function normalizeCSSEntries(obj: CSSEntry[] | CSSObject): CSSEntry[] {
   return (!Array.isArray(obj) ? Object.entries(obj) : obj).filter(i => i[1] != null)
 }
 
-export function normalizeCSSValues(obj: CSSValues): CSSEntries[] {
+export function normalizeCSSValues(obj: CSSValues): CSSEntry[][] {
   if (Array.isArray(obj)) {
     // @ts-expect-error
     if (obj.find(i => !Array.isArray(i) || Array.isArray(i[0])))
@@ -17,7 +17,7 @@ export function normalizeCSSValues(obj: CSSValues): CSSEntries[] {
   }
 }
 
-export function clearIdenticalEntries(entry: CSSEntries): CSSEntries {
+export function clearIdenticalEntries(entry: CSSEntry[]): CSSEntry[] {
   return entry.filter(([k, v], idx) => {
     // remove control keys
     if (k.startsWith('$$'))
@@ -31,7 +31,7 @@ export function clearIdenticalEntries(entry: CSSEntries): CSSEntries {
   })
 }
 
-export function entriesToCss(arr?: CSSEntries) {
+export function entriesToCss(arr?: CSSEntry[]) {
   if (arr == null)
     return ''
   return clearIdenticalEntries(arr)

--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, CSSObject, DynamicMatcher, Rule, RuleContext } from '@unocss/core'
+import type { CSSEntry, CSSObject, DynamicMatcher, Rule, RuleContext } from '@unocss/core'
 import type { Theme } from '../theme'
 import { cornerMap, directionMap, handler as h, parseColor } from '../utils'
 
@@ -18,7 +18,7 @@ export const borders: Rule[] = [
     const v = h.bracket.percent(opacity)
     const d = directionMap[a]
     if (v !== undefined && d)
-      return d.map(i => [`--un-border${i}-opacity`, v]) as CSSEntries
+      return d.map(i => [`--un-border${i}-opacity`, v]) as CSSEntry[]
   }],
 
   // radius
@@ -88,7 +88,7 @@ const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: st
   }
 }
 
-function handlerBorder(m: string[]): CSSEntries | undefined {
+function handlerBorder(m: string[]): CSSEntry[] | undefined {
   const borderSizes = handlerBorderSize(m)
   if (borderSizes) {
     return [
@@ -98,7 +98,7 @@ function handlerBorder(m: string[]): CSSEntries | undefined {
   }
 }
 
-function handlerBorderSize([, a, b]: string[]): CSSEntries | undefined {
+function handlerBorderSize([, a, b]: string[]): CSSEntry[] | undefined {
   const [d, s = '1'] = directionMap[a] ? [a, b] : ['', a]
   const v = h.bracket.px(s)
   if (v !== undefined)
@@ -114,7 +114,7 @@ function handlerBorderColor([, a, c]: string[], ctx: RuleContext) {
   }
 }
 
-function handlerRounded([, a, b]: string[], { theme }: RuleContext<Theme>): CSSEntries | undefined {
+function handlerRounded([, a, b]: string[], { theme }: RuleContext<Theme>): CSSEntry[] | undefined {
   const [d, s = 'DEFAULT'] = cornerMap[a] ? [a, b] : ['', a]
   const v = theme.borderRadius?.[s] || h.auto.rem.fraction.bracket.cssvar(s)
   if (v !== undefined)

--- a/packages/preset-mini/src/rules/border.ts
+++ b/packages/preset-mini/src/rules/border.ts
@@ -17,8 +17,11 @@ export const borders: Rule[] = [
   [/^(?:border|b)-([^-]+)-op(?:acity)?-?(.+)$/, ([, a, opacity]) => {
     const v = h.bracket.percent(opacity)
     const d = directionMap[a]
-    if (v !== undefined && d)
-      return d.map(i => [`--un-border${i}-opacity`, v]) as CSSEntry[]
+    if (v !== undefined && d) {
+      return [
+        d.map(i => [`--un-border${i}-opacity`, v] as CSSEntry),
+      ]
+    }
   }],
 
   // radius
@@ -88,21 +91,24 @@ const borderColorResolver = (direction: string): DynamicMatcher => ([, body]: st
   }
 }
 
-function handlerBorder(m: string[]): CSSEntry[] | undefined {
+function handlerBorder(m: string[]) {
   const borderSizes = handlerBorderSize(m)
   if (borderSizes) {
-    return [
-      ...borderSizes,
-      ['border-style', 'solid'],
-    ]
+    return borderSizes.map(border => [
+      ...border,
+      ['border-style', 'solid'] as CSSEntry,
+    ])
   }
 }
 
-function handlerBorderSize([, a, b]: string[]): CSSEntry[] | undefined {
+function handlerBorderSize([, a, b]: string[]) {
   const [d, s = '1'] = directionMap[a] ? [a, b] : ['', a]
   const v = h.bracket.px(s)
-  if (v !== undefined)
-    return directionMap[d].map(i => [`border${i}-width`, v])
+  if (v !== undefined) {
+    return [
+      directionMap[d].map(i => [`border${i}-width`, v] as CSSEntry),
+    ]
+  }
 }
 
 function handlerBorderColor([, a, c]: string[], ctx: RuleContext) {
@@ -114,9 +120,12 @@ function handlerBorderColor([, a, c]: string[], ctx: RuleContext) {
   }
 }
 
-function handlerRounded([, a, b]: string[], { theme }: RuleContext<Theme>): CSSEntry[] | undefined {
+function handlerRounded([, a, b]: string[], { theme }: RuleContext<Theme>) {
   const [d, s = 'DEFAULT'] = cornerMap[a] ? [a, b] : ['', a]
   const v = theme.borderRadius?.[s] || h.auto.rem.fraction.bracket.cssvar(s)
-  if (v !== undefined)
-    return cornerMap[d].map(i => [`border${i}-radius`, v])
+  if (v !== undefined) {
+    return [
+      cornerMap[d].map(i => [`border${i}-radius`, v] as CSSEntry),
+    ]
+  }
 }

--- a/packages/preset-mini/src/rules/position.ts
+++ b/packages/preset-mini/src/rules/position.ts
@@ -74,10 +74,13 @@ function handleInsetValue(v: string): string | number | undefined {
 
 export const insets: Rule[] = [
   [/^(?:position-|pos-)?(top|left|right|bottom|inset)-(.+)$/, ([, d, v]) => ({ [d]: handleInsetValue(v) })],
-  [/^(?:position-|pos-)?inset-([xy])-(.+)$/, ([, d, v]): CSSEntry[] | undefined => {
+  [/^(?:position-|pos-)?inset-([xy])-(.+)$/, ([, d, v]) => {
     const r = handleInsetValue(v)
-    if (r != null && d in directionMap)
-      return directionMap[d].map(i => [i.slice(1), r])
+    if (r != null && d in directionMap) {
+      return [
+        directionMap[d].map(i => [i.slice(1), r] as CSSEntry),
+      ]
+    }
   }],
 ]
 

--- a/packages/preset-mini/src/rules/position.ts
+++ b/packages/preset-mini/src/rules/position.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, Rule } from '@unocss/core'
+import type { CSSEntry, Rule } from '@unocss/core'
 import { directionMap, handler as h } from '../utils'
 
 const basicSet = ['auto', 'start', 'end', 'center', 'stretch']
@@ -74,7 +74,7 @@ function handleInsetValue(v: string): string | number | undefined {
 
 export const insets: Rule[] = [
   [/^(?:position-|pos-)?(top|left|right|bottom|inset)-(.+)$/, ([, d, v]) => ({ [d]: handleInsetValue(v) })],
-  [/^(?:position-|pos-)?inset-([xy])-(.+)$/, ([, d, v]): CSSEntries | undefined => {
+  [/^(?:position-|pos-)?inset-([xy])-(.+)$/, ([, d, v]): CSSEntry[] | undefined => {
     const r = handleInsetValue(v)
     if (r != null && d in directionMap)
       return directionMap[d].map(i => [i.slice(1), r])

--- a/packages/preset-mini/src/rules/transform.ts
+++ b/packages/preset-mini/src/rules/transform.ts
@@ -1,4 +1,4 @@
-import type { CSSValues, Rule } from '@unocss/core'
+import type { CSSEntry, Rule } from '@unocss/core'
 import { handler as h, xyzMap } from '../utils'
 import { CONTROL_BYPASS_PSEUDO_CLASS } from '../variants/pseudo'
 
@@ -52,31 +52,27 @@ export const transforms: Rule[] = [
   ['origin-top-left', { 'transform-origin': 'top left' }],
 ]
 
-function handleTranslate([, d, b]: string[]): CSSValues | undefined {
+function handleTranslate([, d, b]: string[]) {
   const v = h.bracket.fraction.auto.rem(b)
   if (v != null) {
     return [
       transformBase,
-      [
-        ...xyzMap[d].map((i): [string, string] => [`--un-translate${i}`, v]),
-      ],
+      xyzMap[d].map(i => [`--un-translate${i}`, v] as CSSEntry),
     ]
   }
 }
 
-function handleScale([, d, b]: string[]): CSSValues | undefined {
+function handleScale([, d, b]: string[]) {
   const v = h.bracket.fraction.percent(b)
   if (v != null) {
     return [
       transformBase,
-      [
-        ...xyzMap[d].map((i): [string, string] => [`--un-scale${i}`, v]),
-      ],
+      xyzMap[d].map(i => [`--un-scale${i}`, v] as CSSEntry),
     ]
   }
 }
 
-function handleRotateWithUnit([, b]: string[]): CSSValues | undefined {
+function handleRotateWithUnit([, b]: string[]) {
   const v = h.bracket.number(b)
   if (v != null) {
     return [
@@ -86,7 +82,7 @@ function handleRotateWithUnit([, b]: string[]): CSSValues | undefined {
   }
 }
 
-function handleRotate([, b]: string[]): CSSValues | undefined {
+function handleRotate([, b]: string[]) {
   const v = h.bracket(b)
   if (v != null) {
     return [
@@ -96,7 +92,7 @@ function handleRotate([, b]: string[]): CSSValues | undefined {
   }
 }
 
-function handleSkewWithUnit([, d, b]: string[]): CSSValues | undefined {
+function handleSkewWithUnit([, d, b]: string[]) {
   const v = h.bracket.number(b)
   if (v != null) {
     return [
@@ -106,7 +102,7 @@ function handleSkewWithUnit([, d, b]: string[]): CSSValues | undefined {
   }
 }
 
-function handleSkew([, d, b]: string[]): CSSValues | undefined {
+function handleSkew([, d, b]: string[]) {
   const v = h.bracket(b)
   if (v != null) {
     return [

--- a/packages/preset-mini/src/rules/variables.ts
+++ b/packages/preset-mini/src/rules/variables.ts
@@ -1,4 +1,4 @@
-import type { Rule } from '@unocss/core'
+import type { CSSEntry, Rule } from '@unocss/core'
 import { directionMap } from '../utils'
 
 const variablesAbbrMap: Record<string, string> = {
@@ -41,7 +41,10 @@ export const cssVariables: Rule[] = [
     }
   }],
   [/^(?:border|b)-([^-]+)-\$(.+)$/, ([, a, v]: string[]) => {
-    if (a in directionMap)
-      return directionMap[a].map((i): [string, string] => [`border${i}-color`, `var(--${v})`])
+    if (a in directionMap) {
+      return [
+        directionMap[a].map(i => [`border${i}-color`, `var(--${v})`] as CSSEntry),
+      ]
+    }
   }],
 ]

--- a/packages/preset-mini/src/utils/utilities.ts
+++ b/packages/preset-mini/src/utils/utilities.ts
@@ -15,10 +15,13 @@ export function capitalize<T extends string>(str: T) {
  * @return {DynamicMatcher}  {@link DynamicMatcher}
  * @see {@link directionMap}
  */
-export const directionSize = (propertyPrefix: string): DynamicMatcher => ([_, direction, size]: string[]): CSSEntry[] | undefined => {
+export const directionSize = (propertyPrefix: string): DynamicMatcher => ([_, direction, size]: string[]): CSSEntry[][] | undefined => {
   const v = h.bracket.auto.rem.fraction.cssvar(size)
-  if (v !== undefined)
-    return directionMap[direction].map(i => [`${propertyPrefix}${i}`, v])
+  if (v !== undefined) {
+    return [
+      directionMap[direction].map(i => [`${propertyPrefix}${i}`, v] as CSSEntry),
+    ]
+  }
 }
 
 /**

--- a/packages/preset-mini/src/utils/utilities.ts
+++ b/packages/preset-mini/src/utils/utilities.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, CSSObject, DynamicMatcher, ParsedColorValue, RuleContext } from '@unocss/core'
+import type { CSSEntry, CSSObject, DynamicMatcher, ParsedColorValue, RuleContext } from '@unocss/core'
 import { hex2rgba } from '@unocss/core'
 import type { Theme } from '../theme'
 import { handler as h } from './handlers'
@@ -15,7 +15,7 @@ export function capitalize<T extends string>(str: T) {
  * @return {DynamicMatcher}  {@link DynamicMatcher}
  * @see {@link directionMap}
  */
-export const directionSize = (propertyPrefix: string): DynamicMatcher => ([_, direction, size]: string[]): CSSEntries | undefined => {
+export const directionSize = (propertyPrefix: string): DynamicMatcher => ([_, direction, size]: string[]): CSSEntry[] | undefined => {
   const v = h.bracket.auto.rem.fraction.cssvar(size)
   if (v !== undefined)
     return directionMap[direction].map(i => [`${propertyPrefix}${i}`, v])

--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, VariantFunction, VariantHandler, VariantObject } from '@unocss/core'
+import type { CSSEntry, VariantFunction, VariantHandler, VariantObject } from '@unocss/core'
 import { escapeRegExp, toArray } from '@unocss/core'
 
 export const CONTROL_BYPASS_PSEUDO_CLASS = '$$no-pseudo'
@@ -72,7 +72,7 @@ const PseudoClassFunctionsStr = PseudoClassFunctions.join('|')
 const PseudoClassesRE = new RegExp(`^(${PseudoClassesStr})[:-]`)
 const PseudoClassFunctionsRE = new RegExp(`^(${PseudoClassFunctionsStr})-(${PseudoClassesStr})[:-]`)
 
-function shouldAdd(entires: CSSEntries) {
+function shouldAdd(entires: CSSEntry[]) {
   return !entires.find(i => i[0] === CONTROL_BYPASS_PSEUDO_CLASS) || undefined
 }
 

--- a/packages/preset-wind/src/rules/divide.ts
+++ b/packages/preset-wind/src/rules/divide.ts
@@ -9,7 +9,7 @@ export const divideColors: Rule[] = [
 export const divideSizes: Rule[] = [
   [/^divide-?([xy])$/, handlerDivide],
   [/^divide-?([xy])-?(-?.+)$/, handlerDivide],
-  [/^divide-?([xy])-reverse$/, ([, d]) => [[`--un-divide-${d}-reverse`, 1]]],
+  [/^divide-?([xy])-reverse$/, ([, d]) => ({ [`--un-divide-${d}-reverse`]: 1 })],
 ]
 
 export const divideStyles: Rule[] = [
@@ -22,20 +22,24 @@ export const divideStyles: Rule[] = [
 
 export const divides = [divideSizes, divideColors, divideStyles].flat(1)
 
-function handlerDivide([, a, b]: string[]): CSSEntry[] | undefined {
+function handlerDivide([, a, b]: string[]): CSSEntry[][] | undefined {
   const [d, s = '1'] = directionMap[a] ? [a, b] : ['', a]
   const v = h.bracket.px(s)
 
   if (v != null) {
-    const results = directionMap[d].map((item): [string, string] => {
+    const results = directionMap[d].map((item) => {
       const key = `border${item}-width`
       const value = item.endsWith('right') || item.endsWith('bottom')
         ? `calc(${v} * var(--un-divide-${d}-reverse))`
         : `calc(${v} * calc(1 - var(--un-divide-${d}-reverse)))`
-      return [key, value]
+      return [key, value] as CSSEntry
     })
 
-    if (results)
-      return [[`--un-divide-${d}-reverse`, 0], ...results]
+    if (results) {
+      return [[
+        [`--un-divide-${d}-reverse`, 0],
+        ...results,
+      ]]
+    }
   }
 }

--- a/packages/preset-wind/src/rules/divide.ts
+++ b/packages/preset-wind/src/rules/divide.ts
@@ -1,4 +1,4 @@
-import type { CSSEntries, Rule } from '@unocss/core'
+import type { CSSEntry, Rule } from '@unocss/core'
 import { colorResolver, directionMap, handler as h } from '@unocss/preset-mini/utils'
 
 export const divideColors: Rule[] = [
@@ -22,7 +22,7 @@ export const divideStyles: Rule[] = [
 
 export const divides = [divideSizes, divideColors, divideStyles].flat(1)
 
-function handlerDivide([, a, b]: string[]): CSSEntries | undefined {
+function handlerDivide([, a, b]: string[]): CSSEntry[] | undefined {
   const [d, s = '1'] = directionMap[a] ? [a, b] : ['', a]
   const v = h.bracket.px(s)
 

--- a/packages/preset-wind/src/rules/spacing.ts
+++ b/packages/preset-wind/src/rules/spacing.ts
@@ -1,4 +1,4 @@
-import type { Rule } from '@unocss/core'
+import type { CSSEntry, Rule } from '@unocss/core'
 import { directionSize } from '@unocss/preset-mini/utils'
 
 export const spaces: Rule[] = [
@@ -7,17 +7,18 @@ export const spaces: Rule[] = [
     if (size === 'reverse')
       return { [`--un-space-${direction}-reverse`]: 1 }
 
-    const results = directionSize('margin')(match)?.map((item) => {
+    const results: CSSEntry[][] | undefined = directionSize('margin')(match)?.map((items: CSSEntry[]) => items.map((item) => {
       const value = item[0].endsWith('right') || item[0].endsWith('bottom')
         ? `calc(${item[1]} * var(--un-space-${direction}-reverse))`
         : `calc(${item[1]} * calc(1 - var(--un-space-${direction}-reverse)))`
-      return [item[0], value] as typeof item
-    })
+      return [item[0], value] as CSSEntry
+    }))
+
     if (results) {
-      return [
-        [`--un-space-${direction}-reverse`, 0],
-        ...results,
-      ]
+      return results.map(entry => [
+        [`--un-space-${direction}-reverse`, 0] as CSSEntry,
+        ...entry,
+      ])
     }
   }],
 ]


### PR DESCRIPTION
During some of the refactoring, I struggled to keep track of these two types:

https://github.com/antfu/unocss/blob/db28cfa2dd3aeaa0d2184cc756f7d570b1c54b66/packages/core/src/types.ts#L14
https://github.com/antfu/unocss/blob/db28cfa2dd3aeaa0d2184cc756f7d570b1c54b66/packages/core/src/types.ts#L120


I propose singularizing `CSSEntries` to become `CSSEntry[]` and changing `CSSValues` to:
```ts
export type CSSValues = CSSObject | (CSSObject | CSSEntry[])[]
```

So when you encounter `CSSValues`, it's easier to reason about