### PR TITLE
fix(core)!: resolve dynamic rules

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -315,15 +315,11 @@ export class UnoGenerator {
 
     context.variantHandlers = variantHandlers
 
-    const { rulesDynamic, rulesSize } = this.config
+    const { rulesDynamic } = this.config
 
     // match rules, from last to first
-    for (let i = rulesSize; i >= 0; i--) {
-      const rule = rulesDynamic[i]
-
-      // static rules are omitted as undefined
-      if (!rule)
-        continue
+    for (let j = rulesDynamic.length - 1; j >= 0; j--) {
+      const [i, rule] = rulesDynamic[j]
 
       // ignore internal rules
       if (rule[2]?.internal && !internal)

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -329,15 +329,14 @@ export interface UserConfig<Theme extends {} = {}> extends ConfigBase<Theme>, Us
 export interface UserConfigDefaults<Theme extends {} = {}> extends ConfigBase<Theme>, UserOnlyOptions<Theme> {}
 
 export interface ResolvedConfig extends Omit<
-RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'rules' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
-'rules' | 'shortcuts'
+RequiredByKey<UserConfig, 'mergeSelectors' | 'theme' | 'variants' | 'layers' | 'extractors' | 'blocklist' | 'safelist' | 'preflights' | 'sortLayers'>,
+'shortcuts'
 > {
   shortcuts: Shortcut[]
   variants: VariantObject[]
   preprocess: Preprocessor[]
   postprocess: Postprocessor[]
-  rulesSize: number
-  rulesDynamic: (DynamicRule|undefined)[]
+  rulesDynamic: [number, DynamicRule][]
   rulesStaticMap: Record<string, [number, CSSObject | CSSEntries, RuleMeta | undefined] | undefined>
   options: PresetOptions
 }


### PR DESCRIPTION
Resolve `rulesDynamic` the same time as `rulesStaticMap`. Also changed `rulesDynamic` to `[index, Rule]` since the index needs to be tracked.

Also fixes the dynamic rule counter in inspector.

https://github.com/antfu/unocss/blob/db28cfa2dd3aeaa0d2184cc756f7d570b1c54b66/packages/inspector/client/components/Overview.vue#L23
