### PR TITLE
feat(preset-mini): shadow-inset rule

### DIFF
--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,6 +1,7 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
 import { parseColor } from '../utils'
+import { varEmpty } from './static'
 
 const colorResolver = (body: string, theme: Theme) => {
   const data = parseColor(body, theme)
@@ -31,11 +32,13 @@ export const boxShadows: Rule<Theme>[] = [
     const value = theme.boxShadow?.[d || 'DEFAULT']
     if (value) {
       return {
+        '--un-shadow-inset': varEmpty,
         '--un-shadow-color': '0,0,0',
         '--un-shadow': value,
         'box-shadow': 'var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow)',
       }
     }
   }],
+  ['shadow-inset', { '--un-shadow-inset': 'inset' }],
   [/^shadow-(.+)$/, ([, d], { theme }) => colorResolver(d, theme)],
 ]

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -39,6 +39,6 @@ export const boxShadows: Rule<Theme>[] = [
       }
     }
   }],
-  ['shadow-inset', { '--un-shadow-inset': 'inset' }],
   [/^shadow-(.+)$/, ([, d], { theme }) => colorResolver(d, theme)],
+  ['shadow-inset', { '--un-shadow-inset': 'inset' }],
 ]

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -20,12 +20,12 @@ export const borderRadius = {
 }
 
 export const boxShadow = {
-  'DEFAULT': '0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), 0 1px 2px 0 rgba(var(--un-shadow-color), 0.06)',
-  'sm': '0 1px 2px 0 rgba(var(--un-shadow-color), 0.05)',
-  'md': '0 4px 6px -1px rgba(var(--un-shadow-color), 0.1), 0 2px 4px -1px rgba(var(--un-shadow-color), 0.06)',
-  'lg': '0 10px 15px -3px rgba(var(--un-shadow-color), 0.1), 0 4px 6px -2px rgba(var(--un-shadow-color), 0.05)',
-  'xl': '0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), 0 10px 10px -5px rgba(var(--un-shadow-color), 0.04)',
-  '2xl': '25px 50px -12px rgba(var(--un-shadow-color), 0.25)',
+  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.06)',
+  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05)',
+  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 2px 4px -1px rgba(var(--un-shadow-color), 0.06)',
+  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 4px 6px -2px rgba(var(--un-shadow-color), 0.05)',
+  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 10px 10px -5px rgba(var(--un-shadow-color), 0.04)',
+  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), 0.25)',
   'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), 0.06)',
   'none': 'none',
 }

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -8,5 +8,5 @@ exports[`cli > builds uno.css 1`] = `
 
 exports[`cli > supports unocss.config.js 1`] = `
 "/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-color:0,0,0;--un-shadow:0 1px 2px 0 rgba(var(--un-shadow-color), 0.05);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
+.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
 `;

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -194,10 +194,10 @@ exports[`preset-mini > targets 1`] = `
 .shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.06);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-none{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:none;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 10px 10px -5px rgba(var(--un-shadow-color), 0.04);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-inset{--un-shadow-inset:inset;}
 .shadow-current{--un-shadow-color:currentColor;}
 .shadow-green-500{--un-shadow-color:34,197,94;}
 .shadow-transparent{--un-shadow-color:transparent;}
+.shadow-inset{--un-shadow-inset:inset;}
 .ring{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(59, 130, 246, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color);-webkit-box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
 .ring-10{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(59, 130, 246, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color);-webkit-box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
 .ring-offset{--un-ring-offset-width:1px;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -191,9 +191,10 @@ exports[`preset-mini > targets 1`] = `
 .text-opacity-\\\\[13\\\\.3333333\\\\%\\\\]{--un-text-opacity:13.3333333%;}
 .italic{font-style:italic;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:grayscale;}
-.shadow{--un-shadow-color:0,0,0;--un-shadow:0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), 0 1px 2px 0 rgba(var(--un-shadow-color), 0.06);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-none{--un-shadow-color:0,0,0;--un-shadow:none;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-xl{--un-shadow-color:0,0,0;--un-shadow:0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), 0 10px 10px -5px rgba(var(--un-shadow-color), 0.04);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.06);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-none{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:none;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 10px 10px -5px rgba(var(--un-shadow-color), 0.04);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-inset{--un-shadow-inset:inset;}
 .shadow-current{--un-shadow-color:currentColor;}
 .shadow-green-500{--un-shadow-color:34,197,94;}
 .shadow-transparent{--un-shadow-color:transparent;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -259,6 +259,7 @@ export const presetMiniTargets: string[] = [
   'shadow-none',
   'shadow-xl',
   'shadow-green-500',
+  'shadow-inset',
 
   // size
   'h-auto',


### PR DESCRIPTION
Turned out you can do css `inset` also as variable.

The `inner` keyword is preserved for compatiblity.

https://deploy-preview-340--ecstatic-mestorf-2e8afd.netlify.app/?html=DwEwlgbgBARg5gWgO4AswBcCmUsA90IwA2AhgMYDWUKCAZgK5FFS1Ga4tu4JkD2zAK3oBndGFoBPHpgB2WAE5QMmALbDpczIrgkADggAsAPgBQUKKEhR9ARgNRhKEiF5IEuIkYACwAPTgIU3NLaFt7R2dXd2YIlzcwGWFMdG8-ANM0yCMgA