### PR TITLE
refactor(preset-mini): add variantParentMatcher utility

### DIFF
--- a/packages/preset-mini/src/utils/variants.ts
+++ b/packages/preset-mini/src/utils/variants.ts
@@ -1,13 +1,27 @@
 import type { VariantHandler } from '@unocss/core'
+import { escapeRegExp } from '@unocss/core'
 
 export const variantMatcher = (name: string, selector?: (input: string) => string | undefined) => {
-  const re = new RegExp(`^(${name})[:-]`)
+  const re = new RegExp(`^${escapeRegExp(name)}[:-]`)
   return (input: string): VariantHandler | undefined => {
     const match = input.match(re)
     if (match) {
       return {
-        matcher: input.slice(match[1].length + 1),
+        matcher: input.slice(match[0].length),
         selector,
+      }
+    }
+  }
+}
+
+export const variantParentMatcher = (name: string, parent: string) => {
+  const re = new RegExp(`^${escapeRegExp(name)}[:-]`)
+  return (input: string): VariantHandler | undefined => {
+    const match = input.match(re)
+    if (match) {
+      return {
+        matcher: input.slice(match[0].length),
+        parent,
       }
     }
   }

--- a/packages/preset-mini/src/variants/dark.ts
+++ b/packages/preset-mini/src/variants/dark.ts
@@ -1,41 +1,21 @@
 import type { Variant } from '@unocss/core'
-import { variantMatcher } from '../utils'
+import { variantMatcher, variantParentMatcher } from '../utils'
 
 export const variantColorsMediaOrClass: Variant[] = [
   (v, { options: { dark } }) => {
-    if (dark === 'class') {
-      const match = variantMatcher('dark', input => `.dark $$ ${input}`)(v)
-      if (match)
-        return match
-    }
+    if (dark === 'class')
+      return variantMatcher('dark', input => `.dark $$ ${input}`)(v)
   },
   (v, { options: { dark } }) => {
-    if (dark === 'class') {
-      const match = variantMatcher('light', input => `.light $$ ${input}`)(v)
-      if (match)
-        return match
-    }
+    if (dark === 'class')
+      return variantMatcher('light', input => `.light $$ ${input}`)(v)
   },
   (v, { options: { dark } }) => {
-    if (dark === 'media') {
-      const match = variantMatcher('dark')(v)
-      if (match) {
-        return {
-          ...match,
-          parent: '@media (prefers-color-scheme: dark)',
-        }
-      }
-    }
+    if (dark === 'media')
+      return variantParentMatcher('dark', '@media (prefers-color-scheme: dark)')(v)
   },
   (v, { options: { dark } }) => {
-    if (dark === 'media') {
-      const match = variantMatcher('light')(v)
-      if (match) {
-        return {
-          ...match,
-          parent: '@media (prefers-color-scheme: light)',
-        }
-      }
-    }
+    if (dark === 'media')
+      return variantParentMatcher('light', '@media (prefers-color-scheme: light)')(v)
   },
 ]

--- a/packages/preset-mini/src/variants/prints.ts
+++ b/packages/preset-mini/src/variants/prints.ts
@@ -1,12 +1,3 @@
-import type { VariantFunction } from '@unocss/core'
-import { variantMatcher } from '../utils'
+import { variantParentMatcher } from '../utils'
 
-export const variantPrint: VariantFunction = (v) => {
-  const print = variantMatcher('print')(v)
-  if (print) {
-    return {
-      ...print,
-      parent: '@media print',
-    }
-  }
-}
+export const variantPrint = variantParentMatcher('print', '@media print')

--- a/packages/preset-wind/src/variants/dark.ts
+++ b/packages/preset-wind/src/variants/dark.ts
@@ -1,26 +1,9 @@
 import type { Variant } from '@unocss/core'
-import { variantMatcher } from '@unocss/preset-mini/utils'
+import { variantMatcher, variantParentMatcher } from '@unocss/preset-mini/utils'
 
 export const variantColorsScheme: Variant[] = [
-  variantMatcher('\\.dark', input => `.dark $$ ${input}`),
-  variantMatcher('\\.light', input => `.light $$ ${input}`),
-
-  (v) => {
-    const match = variantMatcher('@dark')(v)
-    if (match) {
-      return {
-        ...match,
-        parent: '@media (prefers-color-scheme: dark)',
-      }
-    }
-  },
-  (v) => {
-    const match = variantMatcher('@light')(v)
-    if (match) {
-      return {
-        ...match,
-        parent: '@media (prefers-color-scheme: light)',
-      }
-    }
-  },
+  variantMatcher('.dark', input => `.dark $$ ${input}`),
+  variantMatcher('.light', input => `.light $$ ${input}`),
+  variantParentMatcher('@dark', '@media (prefers-color-scheme: dark)'),
+  variantParentMatcher('@light', '@media (prefers-color-scheme: light)'),
 ]


### PR DESCRIPTION
I'm adding variants to match those that are in tailwind, and parent with @media has 2 more uses: portrait/landscape and motion reduce.