### PR TITLE
fix(mode): use vite `base` on `global` mode

### DIFF
--- a/packages/inspector/client/components/CodeMirror.vue
+++ b/packages/inspector/client/components/CodeMirror.vue
@@ -13,10 +13,14 @@ const props = defineProps<{
 const modeMap: Record<string, string> = {
   html: 'htmlmixed',
   vue: 'htmlmixed',
+  svelte: 'htmlmixed',
+  astro: 'htmlmixed',
   js: 'javascript',
+  jsx: 'jsx',
   mjs: 'javascript',
   cjs: 'javascript',
   ts: 'typescript',
+  tsx: 'typescript-jsx',
   mts: 'typescript',
 }
 

--- a/packages/inspector/client/components/ModuleInfo.vue
+++ b/packages/inspector/client/components/ModuleInfo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import extractorAttributify from '@unocss/preset-attributify'
+import attributifyPreset from '@unocss/preset-attributify'
 import { fetchModule } from '../composables/fetch'
 
 const props = defineProps<{ id: string }>()
@@ -10,7 +10,7 @@ function openEditor() {
   fetch(`/__open-in-editor?file=${encodeURIComponent(props.id)}`)
 }
 
-const { extractors } = extractorAttributify({ strict: true })
+const { extractors } = attributifyPreset({ strict: true })
 const unmatchedClasses = asyncComputed(async() => {
   const set = new Set<string>()
   if (extractors) {

--- a/packages/inspector/client/components/ModuleInfo.vue
+++ b/packages/inspector/client/components/ModuleInfo.vue
@@ -1,5 +1,5 @@
 <script setup lang="ts">
-import { extractorAttributify } from '@unocss/preset-attributify'
+import extractorAttributify from '@unocss/preset-attributify'
 import { fetchModule } from '../composables/fetch'
 
 const props = defineProps<{ id: string }>()
@@ -10,10 +10,17 @@ function openEditor() {
   fetch(`/__open-in-editor?file=${encodeURIComponent(props.id)}`)
 }
 
-const extractor = extractorAttributify({ strict: true })
+const { extractors } = extractorAttributify({ strict: true })
 const unmatchedClasses = asyncComputed(async() => {
-  const result = await extractor.extract({ code: mod.value?.code || '' } as any) || []
-  return Array.from(result)
+  const set = new Set<string>()
+  if (extractors) {
+    const context = { code: mod.value?.code || '' } as any
+    for (const extractor of extractors) {
+      const result = await extractor.extract(context)
+      result?.forEach(t => set.add(t))
+    }
+  }
+  return Array.from(set)
     .filter(i => !i.startsWith('['))
     .filter(i => !mod.value?.matched.includes(i))
 })

--- a/packages/inspector/node/index.ts
+++ b/packages/inspector/node/index.ts
@@ -1,7 +1,7 @@
 import { dirname, resolve } from 'path'
 import { fileURLToPath } from 'url'
 import sirv from 'sirv'
-import type { Plugin, ResolvedConfig, ViteDevServer } from 'vite'
+import type { Plugin, ViteDevServer } from 'vite'
 import type { UnocssPluginContext } from '@unocss/vite'
 import gzipSize from 'gzip-size'
 import type { ModuleInfo, ProjectInfo } from '../types'
@@ -11,8 +11,6 @@ const _dirname = typeof __dirname !== 'undefined'
   : dirname(fileURLToPath(import.meta.url))
 
 export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
-  let config: ResolvedConfig
-
   async function configureServer(server: ViteDevServer) {
     await ctx.ready
 
@@ -27,7 +25,8 @@ export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
       if (req.url === '/') {
         const info: ProjectInfo = {
           version: ctx.uno.version,
-          root: config.root,
+          // use the resolved config from the dev server
+          root: server.config.root,
           modules: Array.from(ctx.modules.keys()),
           config: ctx.uno.config,
           configSources: (await ctx.ready).sources,
@@ -98,9 +97,6 @@ export default function UnocssInspector(ctx: UnocssPluginContext): Plugin {
   return <Plugin>{
     name: 'unocss:inspector',
     apply: 'serve',
-    configResolved(_config) {
-      config = _config
-    },
     configureServer,
   }
 }

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -1,4 +1,4 @@
-import type { Plugin, ViteDevServer } from 'vite'
+import type { Plugin, ViteDevServer, ResolvedConfig as ViteResolvedConfig } from 'vite'
 import type { UnocssPluginContext } from '../../../../plugins-common'
 import { LAYER_MARK_ALL, getPath, resolveId } from '../../../../plugins-common'
 import { READY_CALLBACK_DEFAULT } from './shared'
@@ -7,6 +7,7 @@ const WARN_TIMEOUT = 2000
 
 export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter }: UnocssPluginContext): Plugin[] {
   const servers: ViteDevServer[] = []
+  let base = ''
 
   const tasks: Promise<any>[] = []
   const entries = new Map<string, string>()
@@ -16,6 +17,14 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
   let lastServed = 0
   let resolved = false
   let resolvedWarnTimer: any
+
+  function configureBase(config: ViteResolvedConfig) {
+    base = config?.base || ''
+    if (base === '/')
+      base = ''
+    else if (base.endsWith('/'))
+      base = base.slice(0, base.length - 1)
+  }
 
   function invalidate(timer = 10) {
     for (const server of servers) {
@@ -70,9 +79,13 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
       async configureServer(_server) {
         servers.push(_server)
         _server.middlewares.use(async(req, res, next) => {
+          let url = req.url
+          if (url && base.length > 0 && url.startsWith(base))
+            url = url.slice(base.length)
+
           setWarnTimer()
-          if (req.url?.startsWith(READY_CALLBACK_DEFAULT)) {
-            const servedTime = +req.url.slice(READY_CALLBACK_DEFAULT.length + 1)
+          if (url?.startsWith(READY_CALLBACK_DEFAULT)) {
+            const servedTime = +url.slice(READY_CALLBACK_DEFAULT.length + 1)
             if (servedTime < lastUpdate)
               invalidate(0)
             res.statusCode = 200
@@ -82,6 +95,9 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
             return next()
           }
         })
+      },
+      configResolved(config) {
+        configureBase(config)
       },
       transform(code, id) {
         if (filter(code, id))
@@ -117,13 +133,16 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
     },
     {
       name: 'unocss:global:post',
+      configResolved(config) {
+        configureBase(config)
+      },
       apply(config, env) {
         return env.command === 'serve' && !config.build?.ssr
       },
       enforce: 'post',
       transform(code, id) {
         if (entries.has(getPath(id)) && code.includes('import.meta.hot'))
-          return `${code}\nawait fetch("${READY_CALLBACK_DEFAULT}/${lastServed}")`
+          return `${code}\nawait fetch("${base}${READY_CALLBACK_DEFAULT}/${lastServed}")`
       },
     },
   ]

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -19,7 +19,7 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
   let resolvedWarnTimer: any
 
   function configResolved(config: ViteResolvedConfig) {
-    base = config?.base || ''
+    base = config.base || ''
     if (base === '/')
       base = ''
     else if (base.endsWith('/'))

--- a/packages/vite/src/modes/global/dev.ts
+++ b/packages/vite/src/modes/global/dev.ts
@@ -18,7 +18,7 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
   let resolved = false
   let resolvedWarnTimer: any
 
-  function configureBase(config: ViteResolvedConfig) {
+  function configResolved(config: ViteResolvedConfig) {
     base = config?.base || ''
     if (base === '/')
       base = ''
@@ -76,6 +76,7 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
       name: 'unocss:global',
       apply: 'serve',
       enforce: 'pre',
+      configResolved,
       async configureServer(_server) {
         servers.push(_server)
         _server.middlewares.use(async(req, res, next) => {
@@ -95,9 +96,6 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
             return next()
           }
         })
-      },
-      configResolved(config) {
-        configureBase(config)
       },
       transform(code, id) {
         if (filter(code, id))
@@ -133,9 +131,7 @@ export function GlobalModeDevPlugin({ uno, tokens, onInvalidate, extract, filter
     },
     {
       name: 'unocss:global:post',
-      configResolved(config) {
-        configureBase(config)
-      },
+      configResolved,
       apply(config, env) {
         return env.command === 'serve' && !config.build?.ssr
       },

--- a/test/fixtures/vite-solid/vite.config.ts
+++ b/test/fixtures/vite-solid/vite.config.ts
@@ -22,7 +22,6 @@ export default defineConfig({
           },
         }),
       ],
-      inspector: true,
     }),
   ],
   build: {


### PR DESCRIPTION
@antfu This PR also fix a problem with the inspector, if you want to include it on a separate PR just request me.

Now the inspector works on all fixtures: `svelte`, `sveltekit`, `react`, `preact`, and `solid`, for `lit` I need to review it (`vite-plugin-inspect` is working).

closes #254
closes #369 