### PR TITLE
feat(preset-mini): add aspect ratio rule keywords

### DIFF
--- a/packages/preset-mini/src/rules/size.ts
+++ b/packages/preset-mini/src/rules/size.ts
@@ -29,6 +29,18 @@ export const sizes: Rule<Theme>[] = [
 ]
 
 export const aspectRatio: Rule[] = [
-  ['aspect-ratio-auto', { 'aspect-ratio': 'auto' }],
-  [/^aspect-ratio-(.+)$/, ([, d]: string[]) => ({ 'aspect-ratio': (/^\d+\/\d+$/.test(d) ? d : null) || h.bracket.cssvar.number(d) })],
+  [/^aspect-(?:ratio-)?(.+)$/, ([, d]: string[]) => {
+    if (/^\d+\/\d+$/.test(d))
+      return { 'aspect-ratio': d }
+
+    const v = {
+      auto: 'auto',
+      square: '1/1',
+      video: '16/9',
+    }[d]
+    if (v != null)
+      return { 'aspect-ratio': v }
+
+    return { 'aspect-ratio': h.bracket.cssvar.number(d) }
+  }],
 ]

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -300,11 +300,13 @@ exports[`preset-mini > targets 1`] = `
 .w-lg{width:32rem;}
 .max-w-screen-lg{max-width:1024px;}
 .min-w-screen-lg{min-width:1024px;}
-.aspect-ratio-auto{aspect-ratio:auto;}
-.aspect-ratio-\\\\[auto_16\\\\/9\\\\]{aspect-ratio:auto 16/9;}
+.aspect-\\\\[auto_16\\\\/9\\\\],.aspect-ratio-\\\\[auto_16\\\\/9\\\\]{aspect-ratio:auto 16/9;}
+.aspect-auto{aspect-ratio:auto;}
 .aspect-ratio-\\\\$var{aspect-ratio:var(--var);}
 .aspect-ratio-0\\\\.7{aspect-ratio:0.7;}
 .aspect-ratio-3\\\\/2{aspect-ratio:3/2;}
+.aspect-ratio-square{aspect-ratio:1/1;}
+.aspect-ratio-video{aspect-ratio:16/9;}
 .cursor-pointer{cursor:pointer;}
 .backface-hidden{backface-visibility:hidden;}
 .pointer-events-auto{pointer-events:auto;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -317,11 +317,14 @@ export const presetMiniTargets: string[] = [
   'w-[calc(calc(100px*10)-4rem)]',
 
   // size - ar
-  'aspect-ratio-auto',
+  'aspect-ratio-square',
+  'aspect-ratio-video',
+  'aspect-auto',
   'aspect-ratio-3/2',
   'aspect-ratio-0.7',
   'aspect-ratio-$var',
   'aspect-ratio-[auto_16/9]',
+  'aspect-[auto_16/9]',
 
   // spacing
   'p-2',


### PR DESCRIPTION
[Follows tailwind keywords.](https://tailwindcss.com/docs/aspect-ratio)

Should the keyword moved to `preset-wind`?