### PR TITLE
refactor(preset-wind): reorder background rules

### DIFF
--- a/packages/preset-wind/src/rules/background.ts
+++ b/packages/preset-wind/src/rules/background.ts
@@ -40,11 +40,6 @@ const bgGradientColorResolver = (mode: 'from' | 'to' | 'via') =>
   }
 
 export const backgroundStyles: Rule[] = [
-  // attachments
-  ['bg-fixed', { 'background-attachment': 'fixed' }],
-  ['bg-local', { 'background-attachment': 'local' }],
-  ['bg-scroll', { 'background-attachment': 'scroll' }],
-
   // blends
   ['bg-blend-multiply', { 'background-blend-mode': 'multiply' }],
   ['bg-blend-screen', { 'background-blend-mode': 'screen' }],
@@ -63,11 +58,7 @@ export const backgroundStyles: Rule[] = [
   ['bg-blend-luminosity', { 'background-blend-mode': 'luminosity' }],
   ['bg-blend-normal', { 'background-blend-mode': 'normal' }],
 
-  // clips
-  ['bg-clip-border', { '-webkit-background-clip': 'border-box', 'background-attachment': 'border-box' }],
-  ['bg-clip-content', { '-webkit-background-clip': 'content-box', 'background-attachment': 'content-box' }],
-  ['bg-clip-padding', { '-webkit-background-clip': 'padding-box', 'background-attachment': 'padding-box' }],
-  ['bg-clip-text', { '-webkit-background-clip': 'text', 'background-attachment': 'text' }],
+  // TODO: bg-[url] { background-image: x }
 
   // gradients
   [/^(?:bg-gradient-)?from-(.+)$/, bgGradientColorResolver('from')],
@@ -79,16 +70,32 @@ export const backgroundStyles: Rule[] = [
 
   // images
   // ignore any center position
-  [/^bg-gradient-to-([trbl]{1,2})$/, ([, d]) => {
+  [/^bg-gradient-to-([rltb]{1,2})$/, ([, d]) => {
     if (d in positionMap)
       return { 'background-image': `linear-gradient(to ${positionMap[d]}, var(--un-gradient-stops))` }
   }],
   ['bg-none', { 'background-image': 'none' }],
 
-  // origins
-  ['bg-origin-border', { 'background-origin': 'border-box' }],
-  ['bg-origin-padding', { 'background-origin': 'padding-box' }],
-  ['bg-origin-content', { 'background-origin': 'content-box' }],
+  ['box-decoration-slice', { 'box-decoration-break': 'slice' }],
+  ['box-decoration-clone', { 'box-decoration-break': 'clone' }],
+
+  // TODO: bg-[number] { background-size: x }
+
+  // size
+  ['bg-auto', { 'background-size': 'auto' }],
+  ['bg-cover', { 'background-size': 'cover' }],
+  ['bg-contain', { 'background-size': 'contain' }],
+
+  // attachments
+  ['bg-fixed', { 'background-attachment': 'fixed' }],
+  ['bg-local', { 'background-attachment': 'local' }],
+  ['bg-scroll', { 'background-attachment': 'scroll' }],
+
+  // clips
+  ['bg-clip-border', { '-webkit-background-clip': 'border-box', 'background-attachment': 'border-box' }],
+  ['bg-clip-content', { '-webkit-background-clip': 'content-box', 'background-attachment': 'content-box' }],
+  ['bg-clip-padding', { '-webkit-background-clip': 'padding-box', 'background-attachment': 'padding-box' }],
+  ['bg-clip-text', { '-webkit-background-clip': 'text', 'background-attachment': 'text' }],
 
   // positions
   // skip 1 & 2 letters shortcut
@@ -102,8 +109,8 @@ export const backgroundStyles: Rule[] = [
   ['bg-repeat-round', { 'background-position': 'round' }],
   ['bg-repeat-space', { 'background-position': 'space' }],
 
-  // size
-  ['bg-auto', { 'background-size': 'auto' }],
-  ['bg-cover', { 'background-size': 'cover' }],
-  ['bg-contain', { 'background-size': 'contain' }],
+  // origins
+  ['bg-origin-border', { 'background-origin': 'border-box' }],
+  ['bg-origin-padding', { 'background-origin': 'padding-box' }],
+  ['bg-origin-content', { 'background-origin': 'content-box' }],
 ]

--- a/packages/preset-wind/src/rules/behaviors.ts
+++ b/packages/preset-wind/src/rules/behaviors.ts
@@ -20,11 +20,6 @@ export const listStyle: Rule[] = [
   ['list-none', { 'list-style-type': 'none' }],
 ]
 
-export const boxDecorationBreaks: Rule[] = [
-  ['decoration-slice', { 'box-decoration-break': 'slice' }],
-  ['decoration-clone', { 'box-decoration-break': 'clone' }],
-]
-
 export const accentOpacity: Rule[] = [
   [/^accent-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-accent-opacity': h.bracket.percent(d) })],
 ]

--- a/packages/preset-wind/src/rules/default.ts
+++ b/packages/preset-wind/src/rules/default.ts
@@ -59,7 +59,7 @@ import { mixBlendModes } from './shadow'
 import { spaces } from './spacing'
 import { hyphens, isolations, objectPositions, screenReadersAccess, textTransforms, writingModes, writingOrientations } from './static'
 import { tables } from './table'
-import { accentColors, accentOpacity, boxDecorationBreaks, caretColors, caretOpacity, imageRenderings, listStyle, overscrolls, scrollBehaviors } from './behaviors'
+import { accentColors, accentOpacity, caretColors, caretOpacity, imageRenderings, listStyle, overscrolls, scrollBehaviors } from './behaviors'
 import { animations } from './animation'
 import { cssVariables } from './variables'
 import { divides } from './divide'
@@ -115,7 +115,6 @@ export const rules: Rule[] = [
   wordBreaks,
   borders,
   bgColors,
-  boxDecorationBreaks,
   backgroundStyles,
   svgUtilities,
   objectPositions,

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -122,14 +122,9 @@ exports[`preset-wind > targets 1`] = `
 .overscroll-x-auto{overscroll-behavior-x:auto;}
 .scroll-auto{scroll-behavior:auto;}
 .decoration-slice{box-decoration-break:slice;}
-.bg-fixed{background-attachment:fixed;}
-.bg-local{background-attachment:local;}
-.bg-scroll{background-attachment:scroll;}
 .bg-blend-color-burn{background-blend-mode:color-burn;}
 .bg-blend-luminosity{background-blend-mode:luminosity;}
 .bg-blend-normal{background-blend-mode:normal;}
-.bg-clip-border{-webkit-background-clip:border-box;background-attachment:border-box;}
-.bg-clip-text{-webkit-background-clip:text;background-attachment:text;}
 .bg-gradient-from-current,.from-current{--un-gradient-from:currentColor;--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-green-600{--un-gradient-from:rgba(22,163,74, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 .bg-gradient-from-green-600\\\\/60{--un-gradient-from:rgba(22,163,74,0.6);--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
@@ -156,13 +151,18 @@ exports[`preset-wind > targets 1`] = `
 .bg-gradient-to-t{background-image:linear-gradient(to top, var(--un-gradient-stops));}
 .bg-gradient-to-tl{background-image:linear-gradient(to top left, var(--un-gradient-stops));}
 .bg-none{background-image:none;}
-.bg-origin-border{background-origin:border-box;}
+.bg-auto{background-size:auto;}
+.bg-cover{background-size:cover;}
+.bg-fixed{background-attachment:fixed;}
+.bg-local{background-attachment:local;}
+.bg-scroll{background-attachment:scroll;}
+.bg-clip-border{-webkit-background-clip:border-box;background-attachment:border-box;}
+.bg-clip-text{-webkit-background-clip:text;background-attachment:text;}
 .bg-bottom{background-position:bottom;}
 .bg-right-bottom{background-position:right bottom;}
 .bg-no-repeat{background-repeat:no-repeat;}
 .bg-repeat-space{background-position:space;}
-.bg-auto{background-size:auto;}
-.bg-cover{background-size:cover;}
+.bg-origin-border{background-origin:border-box;}
 .object-none{object-fit:none;}
 .object-cb{object-position:center bottom;}
 .object-center{object-position:center;}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -121,7 +121,6 @@ exports[`preset-wind > targets 1`] = `
 .overscroll-none{overscroll-behavior:none;}
 .overscroll-x-auto{overscroll-behavior-x:auto;}
 .scroll-auto{scroll-behavior:auto;}
-.decoration-slice{box-decoration-break:slice;}
 .bg-blend-color-burn{background-blend-mode:color-burn;}
 .bg-blend-luminosity{background-blend-mode:luminosity;}
 .bg-blend-normal{background-blend-mode:normal;}
@@ -151,6 +150,7 @@ exports[`preset-wind > targets 1`] = `
 .bg-gradient-to-t{background-image:linear-gradient(to top, var(--un-gradient-stops));}
 .bg-gradient-to-tl{background-image:linear-gradient(to top left, var(--un-gradient-stops));}
 .bg-none{background-image:none;}
+.box-decoration-slice{box-decoration-break:slice;}
 .bg-auto{background-size:auto;}
 .bg-cover{background-size:cover;}
 .bg-fixed{background-attachment:fixed;}

--- a/test/preset-wind-targets.ts
+++ b/test/preset-wind-targets.ts
@@ -78,7 +78,7 @@ export const presetWindiTargets: string[] = [
   'list-none',
   'list-disc',
   'list-outside',
-  'decoration-slice',
+  'box-decoration-slice',
   'accent-op-90',
   'accent-red',
   'caret-op-90',


### PR DESCRIPTION
`decoration-slice` and `decoration-clone` are removed in favor of `box-decoration-slice` and `box-decoration-clone`
https://tailwindcss.com/docs/upgrade-guide#decoration-clone-slice