### PR TITLE
refactor(preset-wind): move space & divide variant into wind

### DIFF
--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -4,14 +4,13 @@ import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
 import { variantColorsMediaOrClass } from './dark'
 import { variantLanguageDirections } from './directions'
-import { variantImportant, variantNegative, variantSpace } from './misc'
+import { variantImportant, variantNegative } from './misc'
 import { variantMotions } from './motions'
 import { variantOrientations } from './orientations'
 import { variantPrint } from './prints'
 import { partClasses, variantPseudoClassFunctions, variantPseudoClasses, variantPseudoElements, variantTaggedPseudoClasses } from './pseudo'
 
 export const variants: Variant<Theme>[] = [
-  variantSpace,
   variantNegative,
   variantImportant,
   variantPrint,

--- a/packages/preset-mini/src/variants/misc.ts
+++ b/packages/preset-mini/src/variants/misc.ts
@@ -36,14 +36,3 @@ export const variantNegative: Variant = {
   },
 
 }
-
-export const variantSpace: Variant = (matcher) => {
-  if (/^space-?([xy])-?(-?.+)$/.test(matcher) || /^divide-/.test(matcher)) {
-    return {
-      matcher,
-      selector: (input) => {
-        return `${input}>:not([hidden])~:not([hidden])`
-      },
-    }
-  }
-}

--- a/packages/preset-wind/src/variants/default.ts
+++ b/packages/preset-wind/src/variants/default.ts
@@ -2,8 +2,10 @@ import type { Variant } from '@unocss/core'
 import type { Theme } from '@unocss/preset-mini'
 import { variants as miniVariants } from '@unocss/preset-mini/variants'
 import { variantColorsScheme } from './dark'
+import { variantSpaceAndDivide } from './misc'
 
 export const variants: Variant<Theme>[] = [
+  variantSpaceAndDivide,
   ...miniVariants,
   ...variantColorsScheme,
 ]

--- a/packages/preset-wind/src/variants/index.ts
+++ b/packages/preset-wind/src/variants/index.ts
@@ -1,3 +1,4 @@
 /* @export-submodules */
 export * from './dark'
 export * from './default'
+export * from './misc'

--- a/packages/preset-wind/src/variants/misc.ts
+++ b/packages/preset-wind/src/variants/misc.ts
@@ -1,0 +1,12 @@
+import type { Variant } from '@unocss/core'
+
+export const variantSpaceAndDivide: Variant = (matcher) => {
+  if (/^space-?([xy])-?(-?.+)$/.test(matcher) || /^divide-/.test(matcher)) {
+    return {
+      matcher,
+      selector: (input) => {
+        return `${input}>:not([hidden])~:not([hidden])`
+      },
+    }
+  }
+}


### PR DESCRIPTION
The rules are in `preset-wind` but the variant is in `preset-mini`.