### PR TITLE
feat(preset-mini): add/update missing rules

### DIFF
--- a/packages/preset-mini/src/rules/align.ts
+++ b/packages/preset-mini/src/rules/align.ts
@@ -7,7 +7,7 @@ const verticalAlignAlias: Record<string, string> = {
 }
 
 export const verticalAligns: Rule[] = [
-  [/^(?:vertical|align|v)-(baseline|top|bottom|middle|text-top|text-bottom|mid|base|btm)$/, ([, v]) => ({ 'vertical-align': verticalAlignAlias[v] || v })],
+  [/^(?:vertical|align|v)-(baseline|top|middle|bottom|text-top|text-bottom|sub|super|mid|base|btm)$/, ([, v]) => ({ 'vertical-align': verticalAlignAlias[v] || v })],
 ]
 
 export const textAligns: Rule[] = [

--- a/packages/preset-mini/src/rules/behaviors.ts
+++ b/packages/preset-mini/src/rules/behaviors.ts
@@ -13,7 +13,7 @@ export const outline: Rule[] = [
 
   // style
   ['outline', { 'outline-style': 'solid' }],
-  [/^outline-(auto|dotted|dashed|solid|double|groove|ridge|inset|outset|inherit|initial|revert|unset)$/, ([, c]) => ({ 'outline-style': c })],
+  [/^outline-(auto|dashed|dotted|double|hidden|solid|groove|ridge|inset|outset|inherit|initial|revert|unset)$/, ([, c]) => ({ 'outline-style': c })],
   ['outline-none', { 'outline': '2px solid transparent', 'outline-offset': '2px' }],
 ]
 
@@ -25,5 +25,5 @@ export const appearance: Rule[] = [
 ]
 
 export const willChange: Rule[] = [
-  [/^will-change-(.+)/, ([, p]) => ({ 'will-change': h.properties.global(p) })],
+  [/^will-change-(.+)/, ([, p]) => ({ 'will-change': h.properties.auto.global(p) })],
 ]

--- a/packages/preset-mini/src/rules/decoration.ts
+++ b/packages/preset-mini/src/rules/decoration.ts
@@ -2,10 +2,11 @@ import type { CSSObject, Rule } from '@unocss/core'
 import { colorResolver, handler as h } from '../utils'
 
 export const textDecorations: Rule[] = [
-  ['underline', { 'text-decoration': 'underline' }],
-  ['line-through', { 'text-decoration': 'line-through' }],
-  ['decoration-underline', { 'text-decoration': 'underline' }],
-  ['decoration-line-through', { 'text-decoration': 'line-through' }],
+  ['underline', { 'text-decoration-line': 'underline' }],
+  ['overline', { 'text-decoration-line': 'overline' }],
+  ['line-through', { 'text-decoration-line': 'line-through' }],
+  ['decoration-underline', { 'text-decoration-line': 'underline' }],
+  ['decoration-line-through', { 'text-decoration-line': 'line-through' }],
 
   // size
   [/^(?:underline|decoration)-(?:size-)?(.+)$/, ([, s]) => ({ 'text-decoration-thickness': h.bracket.px(s) })],

--- a/packages/preset-mini/src/rules/layout.ts
+++ b/packages/preset-mini/src/rules/layout.ts
@@ -3,6 +3,7 @@ import type { Rule } from '@unocss/core'
 const overflowValues = [
   'auto',
   'hidden',
+  'clip',
   'visible',
   'scroll',
 ]

--- a/packages/preset-mini/src/rules/static.ts
+++ b/packages/preset-mini/src/rules/static.ts
@@ -53,7 +53,7 @@ export const contents: Rule[] = [
 
 export const breaks: Rule[] = [
   ['break-normal', { 'overflow-wrap': 'normal', 'word-break': 'normal' }],
-  ['break-word', { 'overflow-wrap': 'break-word' }],
+  ['break-words', { 'overflow-wrap': 'break-word' }],
   ['break-all', { 'word-break': 'break-all' }],
 ]
 

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -161,7 +161,7 @@ exports[`preset-mini > targets 1`] = `
 .indent-1\\\\/2{text-indent:50%;}
 .indent-lg{text-indent:2rem;}
 .text-clip{text-overflow:clip;}
-.underline{text-decoration:underline;}
+.underline{text-decoration-line:underline;}
 .decoration-5,
 .underline-5{text-decoration-thickness:5px;}
 .underline-1rem{text-decoration-thickness:1rem;}
@@ -380,14 +380,17 @@ exports[`preset-mini > targets 1`] = `
 .v-mid{vertical-align:middle;}
 .v-top{vertical-align:top;}
 .vertical-baseline{vertical-align:baseline;}
+.vertical-super{vertical-align:super;}
 .select-all{user-select:all;}
 .select-none{user-select:none;}
 .whitespace-pre-wrap{white-space:pre-wrap;}
 .ws-nowrap{white-space:nowrap;}
 .break-normal{overflow-wrap:normal;word-break:normal;}
+.break-words{overflow-wrap:break-word;}
 .overflow-auto{overflow:auto;}
 .of-y-visible{overflow-y:visible;}
 .overflow-x-scroll{overflow-x:scroll;}
+.overflow-y-clip{overflow-y:clip;}
 .outline-110{outline-width:27.5rem;}
 .outline-size-\\\\[var\\\\(--width\\\\)\\\\]{outline-width:var(--width);}
 .outline-size-4,
@@ -402,6 +405,7 @@ exports[`preset-mini > targets 1`] = `
 .outline-offset-4{outline-offset:1rem;}
 .outline,
 .outline-solid{outline-style:solid;}
+.outline-hidden{outline-style:hidden;}
 .outline-inset{outline-style:inset;}
 .outline-unset{outline-style:unset;}
 .outline-none{outline:2px solid transparent;outline-offset:2px;}
@@ -506,6 +510,7 @@ exports[`preset-mini > targets 1`] = `
 .transform-cpu{transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .transform-none{transform:none;}
 .origin-top-left{transform-origin:top left;}
+.will-change-auto{will-change:auto;}
 .will-change-margin\\\\2c padding{will-change:margin,padding;}
 .will-change-padding\\\\2c margin{will-change:padding,margin;}
 .will-change-transform{will-change:transform;}
@@ -532,7 +537,7 @@ exports[`preset-mini > targets 1`] = `
 }
 @media print{
 .print\\\\:block{display:block;}
-.print\\\\:link\\\\:\\\\!underline:link{text-decoration:underline !important;}
+.print\\\\:link\\\\:\\\\!underline:link{text-decoration-line:underline !important;}
 }
 @media (max-width: 1024px){
 .lt-lg\\\\:m2{margin:0.5rem;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -1,6 +1,7 @@
 export const presetMiniTargets: string[] = [
   // align
   'vertical-baseline',
+  'vertical-super',
   'align-text-bottom',
   'v-top',
   'v-mid',
@@ -9,6 +10,7 @@ export const presetMiniTargets: string[] = [
   // behaviors
   'outline-none',
   'outline',
+  'outline-hidden',
   'outline-gray',
   'outline-gray-400',
   'outline-size-4',
@@ -30,6 +32,7 @@ export const presetMiniTargets: string[] = [
   'will-change-padding,margin',
   'will-change-transform',
   'will-change-unset',
+  'will-change-auto',
 
   // border
   'b-2',
@@ -220,6 +223,7 @@ export const presetMiniTargets: string[] = [
   'of-y-visible',
   'overflow-auto',
   'overflow-x-scroll',
+  'overflow-y-clip',
 
   // position
   'static',
@@ -359,6 +363,7 @@ export const presetMiniTargets: string[] = [
   'ws-nowrap',
   'content-empty',
   'break-normal',
+  'break-words',
   'text-clip',
   'case-upper', // !
   'case-normal', // !


### PR DESCRIPTION
- add `sub` & `super` to vertical align
- add `hidden` to outline
- add `auto` to will-change
- add `overline` decoration
- update `text-decoration` to `text-decoration-line`
- add `clip` to overflow values
- change/fix `break-words` from `break-word`