### PR TITLE
feat(preset-wind): add/update missing rules

### DIFF
--- a/packages/preset-wind/src/rules/behaviors.ts
+++ b/packages/preset-wind/src/rules/behaviors.ts
@@ -20,20 +20,14 @@ export const listStyle: Rule[] = [
   ['list-none', { 'list-style-type': 'none' }],
 ]
 
-export const accentOpacity: Rule[] = [
+export const accents: Rule[] = [
+  [/^accent-(.+)$/, colorResolver('accent-color', 'accent')],
   [/^accent-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-accent-opacity': h.bracket.percent(d) })],
 ]
 
-export const accentColors: Rule[] = [
-  [/^accent-(.+)$/, colorResolver('accent-color', 'accent')],
-]
-
-export const caretOpacity: Rule[] = [
-  [/^caret-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-caret-opacity': h.bracket.percent(d) })],
-]
-
-export const caretColors: Rule[] = [
+export const carets: Rule[] = [
   [/^caret-(.+)$/, colorResolver('caret-color', 'caret')],
+  [/^caret-op(?:acity)?-?(.+)$/, ([, d]) => ({ '--un-caret-opacity': h.bracket.percent(d) })],
 ]
 
 export const imageRenderings: Rule[] = [

--- a/packages/preset-wind/src/rules/default.ts
+++ b/packages/preset-wind/src/rules/default.ts
@@ -59,7 +59,7 @@ import { mixBlendModes } from './shadow'
 import { spaces } from './spacing'
 import { hyphens, isolations, objectPositions, screenReadersAccess, textTransforms, writingModes, writingOrientations } from './static'
 import { tables } from './table'
-import { accentColors, accentOpacity, caretColors, caretOpacity, imageRenderings, listStyle, overscrolls, scrollBehaviors } from './behaviors'
+import { accents, carets, imageRenderings, listStyle, overscrolls, scrollBehaviors } from './behaviors'
 import { animations } from './animation'
 import { cssVariables } from './variables'
 import { divides } from './divide'
@@ -129,16 +129,15 @@ export const rules: Rule[] = [
   textColors,
   textDecorations,
   fontSmoothings,
+  // TODO placeholders,
   tabSizes,
   textStrokes,
   textShadows,
   hyphens,
   writingModes,
   writingOrientations,
-  caretColors,
-  caretOpacity,
-  accentColors,
-  accentOpacity,
+  carets,
+  accents,
   opacity,
   mixBlendModes,
   boxShadows,

--- a/packages/preset-wind/src/rules/scrolls.ts
+++ b/packages/preset-wind/src/rules/scrolls.ts
@@ -4,7 +4,7 @@ import { CONTROL_BYPASS_PSEUDO_CLASS } from '@unocss/preset-mini/variants'
 
 export const scrolls: Rule[] = [
   // snap type
-  [/^snap-(x|y|base)$/, ([, d]) => [
+  [/^snap-(x|y|both)$/, ([, d]) => [
     {
       '--un-scroll-snap-strictness': 'proximity',
       [CONTROL_BYPASS_PSEUDO_CLASS]: '',

--- a/packages/preset-wind/src/rules/spacing.ts
+++ b/packages/preset-wind/src/rules/spacing.ts
@@ -3,9 +3,7 @@ import { directionSize } from '@unocss/preset-mini/utils'
 
 export const spaces: Rule[] = [
   [/^space-?([xy])-?(-?.+)$/, (match) => {
-    const [, direction, size] = match
-    if (size === 'reverse')
-      return { [`--un-space-${direction}-reverse`]: 1 }
+    const [, direction] = match
 
     const results = directionSize('margin')(match)?.map((item) => {
       const value = item[0].endsWith('right') || item[0].endsWith('bottom')
@@ -13,6 +11,7 @@ export const spaces: Rule[] = [
         : `calc(${item[1]} * calc(1 - var(--un-space-${direction}-reverse)))`
       return [item[0], value] as typeof item
     })
+
     if (results) {
       return [
         [`--un-space-${direction}-reverse`, 0],
@@ -20,4 +19,6 @@ export const spaces: Rule[] = [
       ]
     }
   }],
+
+  [/^space-?([xy])-reverse$/, ([, d]) => ({ [`--un-space-${d}-reverse`]: 1 })],
 ]

--- a/packages/preset-wind/src/rules/static.ts
+++ b/packages/preset-wind/src/rules/static.ts
@@ -71,6 +71,7 @@ export const screenReadersAccess: Rule[] = [
 export const isolations: Rule[] = [
   ['isolate', { isolation: 'isolate' }],
   ['isolate-auto', { isolation: 'auto' }],
+  ['isolation-auto', { isolation: 'auto' }],
 ]
 
 export const objectPositions: Rule[] = [
@@ -82,6 +83,5 @@ export const objectPositions: Rule[] = [
   ['object-none', { 'object-fit': 'none' }],
 
   // object position
-  // skip dashed rules
-  [/^object-([\w]+)$/, ([, s]) => ({ 'object-position': positionMap[s] })],
+  [/^object-([-\w]+)$/, ([, s]) => ({ 'object-position': positionMap[s] })],
 ]

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -36,7 +36,8 @@ exports[`preset-wind > targets 1`] = `
 .line-clamp-7{overflow:hidden;display:-webkit-box;-webkit-box-orient:vertical;-webkit-line-clamp:7;line-clamp:7;}
 .line-clamp-none{-webkit-line-clamp:unset;line-clamp:unset;}
 .isolate{isolation:isolate;}
-.isolate-auto{isolation:auto;}
+.isolate-auto,
+.isolation-auto{isolation:auto;}
 .inline-table{display:inline-table;}
 .table{display:table;}
 .table-caption{display:table-caption;}
@@ -89,7 +90,9 @@ exports[`preset-wind > targets 1`] = `
 .touch-pinch-zoom{--un-pinch-zoom:pinch-zoom;touch-action:var(--un-touch-action);}
 .touch-manipulation{touch-action:manipulation;}
 .touch-none{touch-action:none;}
+.snap-both,
 .snap-y{--un-scroll-snap-strictness:proximity;}
+.snap-both{scroll-snap-type:both var(--un-scroll-snap-strictness);}
 .snap-y{scroll-snap-type:y var(--un-scroll-snap-strictness);}
 .snap-mandatory{--un-scroll-snap-strictness:mandatory;}
 .snap-none{scroll-snap-type:none;}
@@ -123,8 +126,8 @@ exports[`preset-wind > targets 1`] = `
 .-space-x-4>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(-1rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(-1rem * var(--un-space-x-reverse));}
 .space-x-\\\\$space>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(var(--space) * calc(1 - var(--un-space-x-reverse)));margin-right:calc(var(--space) * var(--un-space-x-reverse));}
 .space-x-2>:not([hidden])~:not([hidden]){--un-space-x-reverse:0;margin-left:calc(0.5rem * calc(1 - var(--un-space-x-reverse)));margin-right:calc(0.5rem * var(--un-space-x-reverse));}
-.space-x-reverse>:not([hidden])~:not([hidden]){--un-space-x-reverse:1;}
 .space-y-4>:not([hidden])~:not([hidden]){--un-space-y-reverse:0;margin-top:calc(1rem * calc(1 - var(--un-space-y-reverse)));margin-bottom:calc(1rem * var(--un-space-y-reverse));}
+.space-x-reverse>:not([hidden])~:not([hidden]){--un-space-x-reverse:1;}
 .divide-x-4>:not([hidden])~:not([hidden]){--un-divide-x-reverse:0;border-left-width:calc(4px * calc(1 - var(--un-divide-x-reverse)));border-right-width:calc(4px * var(--un-divide-x-reverse));}
 .divide-y-4>:not([hidden])~:not([hidden]){--un-divide-y-reverse:0;border-top-width:calc(4px * calc(1 - var(--un-divide-y-reverse)));border-bottom-width:calc(4px * var(--un-divide-y-reverse));}
 .divide-x-reverse>:not([hidden])~:not([hidden]){--un-divide-x-reverse:1;}
@@ -188,8 +191,10 @@ exports[`preset-wind > targets 1`] = `
 .bg-repeat-space{background-position:space;}
 .bg-origin-border{background-origin:border-box;}
 .object-none{object-fit:none;}
-.object-cb{object-position:center bottom;}
+.object-cb,
+.object-center-bottom{object-position:center bottom;}
 .object-center{object-position:center;}
+.object-center-top,
 .object-ct{object-position:center top;}
 .dark .\\\\.dark\\\\:text-xl{font-size:1.25rem;line-height:1.75rem;}
 .capitalize{text-transform:capitalize;}

--- a/test/preset-wind-targets.ts
+++ b/test/preset-wind-targets.ts
@@ -170,6 +170,7 @@ export const presetWindiTargets: string[] = [
 
   // scrolls
   'snap-y',
+  'snap-both',
   'snap-mandatory',
   'snap-none',
   'snap-center',
@@ -204,10 +205,13 @@ export const presetWindiTargets: string[] = [
   'not-sr-only',
   'isolate',
   'isolate-auto',
+  'isolation-auto',
   'object-none',
   'object-center',
   'object-ct',
   'object-cb',
+  'object-center-top',
+  'object-center-bottom',
 
   // tables
   'border-collapse',


### PR DESCRIPTION
- merge accent opacity and accent colors exports
- merge caret opacity and caret colors exports
- change/fix `snap-both` from `snap-base`
- split `space-[xy]-reverse` rule
- add `isolation-auto`
- add support for expanded object position keywords