### PR TITLE
refactor(preset-mini): update size & aspect ratio

### DIFF
--- a/packages/preset-mini/src/theme/size.ts
+++ b/packages/preset-mini/src/theme/size.ts
@@ -10,8 +10,6 @@ export const baseSize = {
   '5xl': '64rem',
   '6xl': '72rem',
   '7xl': '80rem',
-  'min': 'min-content',
-  'max': 'max-content',
   'prose': '65ch',
 }
 


### PR DESCRIPTION
- move `min` & `max` from theme to rule. Theme is still prioritized, so overriding the theme will still have effect.
- add `[size]-fit` for `fit-content`
- refactor aspect ratio