### PR TITLE
feat(core): deduplicate shortcut instead of merging

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -430,7 +430,7 @@ export class UnoGenerator {
       .map(([e, index], selector, mediaQuery) => {
         const split = e.filter(entries => entries.filter(entry => entry[0] === CONTROL_SHORTCUT_NO_MERGE).length > 0)
         const rest = e.filter(entries => entries.filter(entry => entry[0] === CONTROL_SHORTCUT_NO_MERGE).length === 0)
-        return [...split, rest.flat(1)].map((entries): StringifiedUtil | undefined  => {
+        return [...split, rest.flat(1)].map((entries): StringifiedUtil | undefined => {
           const body = entriesToCss(entries)
           if (body)
             return [index, selector, body, mediaQuery, meta]

--- a/packages/core/src/utils/helpers.ts
+++ b/packages/core/src/utils/helpers.ts
@@ -2,6 +2,7 @@ import type { ParsedUtil, RawUtil, StringifiedUtil, Variant, VariantObject } fro
 
 export const attributifyRE = /^\[(.+?)~?="(.*)"\]$/
 export const validateFilterRE = /(?!\d|-{2}|-\d)[a-zA-Z0-9\u00A0-\uFFFF-_:%-?]/
+export const CONTROL_SHORTCUT_NO_MERGE = '$$shortcut-no-merge'
 
 export function isAttributifySelector(selector: string) {
   return selector.match(attributifyRE)

--- a/packages/preset-mini/src/rules/transform.ts
+++ b/packages/preset-mini/src/rules/transform.ts
@@ -1,18 +1,17 @@
 import type { CSSValues, Rule } from '@unocss/core'
+import { CONTROL_SHORTCUT_NO_MERGE } from '@unocss/core'
 import { handler as h, positionMap, xyzMap } from '../utils'
-import { CONTROL_BYPASS_PSEUDO_CLASS } from '../variants/pseudo'
 
 const transformGpu = {
-  transform: 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translate3d(var(--un-translate-x), var(--un-translate-y), var(--un-translate-z))',
-  [CONTROL_BYPASS_PSEUDO_CLASS]: '',
+  '--un-transform': 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translate3d(var(--un-translate-x), var(--un-translate-y), var(--un-translate-z))',
 }
 
 const transformCpu = {
-  transform: 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z))',
-  [CONTROL_BYPASS_PSEUDO_CLASS]: '',
+  '--un-transform': 'rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z))',
 }
 
 const transformBase = {
+  [CONTROL_SHORTCUT_NO_MERGE]: '',
   '--un-rotate': 0,
   '--un-scale-x': 1,
   '--un-scale-y': 1,
@@ -26,9 +25,6 @@ const transformBase = {
 }
 
 export const transforms: Rule[] = [
-  // base
-  ['transform', transformBase],
-
   // origins
   // skip 1 & 2 letters shortcut
   [/^origin-([-\w]{3,})$/, ([, s]) => ({ 'transform-origin': positionMap[s] })],
@@ -45,6 +41,9 @@ export const transforms: Rule[] = [
   // style
   ['preserve-3d', { 'transform-style': 'preserve-3d' }],
   ['preserve-flat', { 'transform-style': 'flat' }],
+
+  // base
+  [/^transform$/, () => [transformBase, { transform: 'var(--un-transform)' }]],
   ['transform-gpu', transformGpu],
   ['transform-cpu', transformCpu],
   ['transform-none', { transform: 'none' }],
@@ -55,7 +54,10 @@ function handleTranslate([, d, b]: string[]): CSSValues | undefined {
   if (v != null) {
     return [
       transformBase,
-      xyzMap[d].map((i): [string, string] => [`--un-translate${i}`, v]),
+      [
+        ...xyzMap[d].map((i): [string, string] => [`--un-translate${i}`, v]),
+        ['transform', 'var(--un-transform)'],
+      ],
     ]
   }
 }
@@ -65,7 +67,10 @@ function handleScale([, d, b]: string[]): CSSValues | undefined {
   if (v != null) {
     return [
       transformBase,
-      xyzMap[d].map((i): [string, string] => [`--un-scale${i}`, v]),
+      [
+        ...xyzMap[d].map((i): [string, string] => [`--un-scale${i}`, v]),
+        ['transform', 'var(--un-transform)'],
+      ],
     ]
   }
 }
@@ -75,7 +80,10 @@ function handleRotate([, b]: string[]): CSSValues | undefined {
   if (v != null) {
     return [
       transformBase,
-      { '--un-rotate': v },
+      {
+        '--un-rotate': v,
+        'transform': 'var(--un-transform)',
+      },
     ]
   }
 }
@@ -85,7 +93,10 @@ function handleSkew([, d, b]: string[]): CSSValues | undefined {
   if (v != null) {
     return [
       transformBase,
-      { [`--un-skew-${d}`]: v },
+      {
+        [`--un-skew-${d}`]: v,
+        transform: 'var(--un-transform)',
+      },
     ]
   }
 }

--- a/test/__snapshots__/postprocess.test.ts.snap
+++ b/test/__snapshots__/postprocess.test.ts.snap
@@ -2,7 +2,7 @@
 
 exports[`postprocess 1`] = `
 "/* layer: default */
-.scale-100{--hello-rotate:0;--hello-scale-x:1;--hello-scale-y:1;--hello-scale-z:1;--hello-skew-x:0;--hello-skew-y:0;--hello-translate-x:0;--hello-translate-y:0;--hello-translate-z:0;transform:rotate(var(--hello-rotate)) scaleX(var(--hello-scale-x)) scaleY(var(--hello-scale-y)) scaleZ(var(--hello-scale-z)) skewX(var(--hello-skew-x)) skewY(var(--hello-skew-y)) translateX(var(--hello-translate-x)) translateY(var(--hello-translate-y)) translateZ(var(--hello-translate-z));}
-.scale-100{--hello-scale-x:1;--hello-scale-y:1;}
+.scale-100{--hello-rotate:0;--hello-scale-x:1;--hello-scale-y:1;--hello-scale-z:1;--hello-skew-x:0;--hello-skew-y:0;--hello-translate-x:0;--hello-translate-y:0;--hello-translate-z:0;--hello-transform:rotate(var(--hello-rotate)) scaleX(var(--hello-scale-x)) scaleY(var(--hello-scale-y)) scaleZ(var(--hello-scale-z)) skewX(var(--hello-skew-x)) skewY(var(--hello-skew-y)) translateX(var(--hello-translate-x)) translateY(var(--hello-translate-y)) translateZ(var(--hello-translate-z));}
+.scale-100{--hello-scale-x:1;--hello-scale-y:1;transform:var(--hello-transform);}
 .text-opacity-50{--hi-text-opacity:0.5;}"
 `;

--- a/test/__snapshots__/preset-attributify.test.ts.snap
+++ b/test/__snapshots__/preset-attributify.test.ts.snap
@@ -116,13 +116,14 @@ exports[`attributify > fixture1 1`] = `
 [inline-block=\\"\\"]{display:inline-block;}
 [flex~=\\"\\\\~\\"]{display:flex;}
 [flex~=\\"col\\"]{flex-direction:column;}
-[transform=\\"\\"],
 [translate-x-100\\\\%=\\"\\"],
 [rotate-30=\\"\\"],
-[rotate-60=\\"\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
-[translate-x-100\\\\%=\\"\\"]{--un-translate-x:100%;}
-[rotate-30=\\"\\"]{--un-rotate:30deg;}
-[rotate-60=\\"\\"]{--un-rotate:60deg;}
+[rotate-60=\\"\\"],
+[transform=\\"\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+[translate-x-100\\\\%=\\"\\"]{--un-translate-x:100%;transform:var(--un-transform);}
+[rotate-30=\\"\\"]{--un-rotate:30deg;transform:var(--un-transform);}
+[rotate-60=\\"\\"]{--un-rotate:60deg;transform:var(--un-transform);}
+[transform=\\"\\"]{transform:var(--un-transform);}
 [border~=\\"\\\\32 \\"]{border-width:2px;border-style:solid;}
 [border~=\\"blue-200\\"]{--un-border-opacity:1;border-color:rgba(191,219,254,var(--un-border-opacity));}
 [border~=\\"rounded-xl\\"]{border-radius:0.75rem;}
@@ -166,11 +167,11 @@ exports[`attributify > fixture2 1`] = `
 [peer=\\"\\"]:focus~[peer-focus~=\\"-translate-y-4\\"],
 [peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"-translate-y-4\\"],
 [peer=\\"\\"]:focus~[peer-focus~=\\"scale-75\\"],
-[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 [peer=\\"\\"]:focus~[peer-focus~=\\"-translate-y-4\\"],
-[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"-translate-y-4\\"]{--un-translate-y:-1rem;}
+[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"-translate-y-4\\"]{--un-translate-y:-1rem;transform:var(--un-transform);}
 [peer=\\"\\"]:focus~[peer-focus~=\\"scale-75\\"],
-[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-scale-x:0.75;--un-scale-y:0.75;}
+[peer=\\"\\"]:not(:placeholder-shown)~[peer-not-placeholder-shown~=\\"scale-75\\"]{--un-scale-x:0.75;--un-scale-y:0.75;transform:var(--un-transform);}
 [select-none=\\"\\"]{user-select:none;}
 [bg-gradient~=\\"from-yellow-400\\"]{--un-gradient-from:rgba(250,204,21, var(--un-from-opacity, 1));--un-gradient-stops:var(--un-gradient-from), var(--un-gradient-to, rgba(255, 255, 255, 0));}
 [bg-gradient~=\\"to-pink-500\\"]{--un-gradient-to:rgba(236,72,153, var(--un-to-opacity, 1));}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -4,8 +4,8 @@ exports[`preset-mini > custom var prefix 1`] = `
 "/* layer: default */
 .text-red{--hi-text-opacity:1;color:rgba(248,113,113,var(--hi-text-opacity));}
 .text-opacity-50{--hi-text-opacity:0.5;}
-.scale-100{--hi-rotate:0;--hi-scale-x:1;--hi-scale-y:1;--hi-scale-z:1;--hi-skew-x:0;--hi-skew-y:0;--hi-translate-x:0;--hi-translate-y:0;--hi-translate-z:0;transform:rotate(var(--hi-rotate)) scaleX(var(--hi-scale-x)) scaleY(var(--hi-scale-y)) scaleZ(var(--hi-scale-z)) skewX(var(--hi-skew-x)) skewY(var(--hi-skew-y)) translateX(var(--hi-translate-x)) translateY(var(--hi-translate-y)) translateZ(var(--hi-translate-z));}
-.scale-100{--hi-scale-x:1;--hi-scale-y:1;}"
+.scale-100{--hi-rotate:0;--hi-scale-x:1;--hi-scale-y:1;--hi-scale-z:1;--hi-skew-x:0;--hi-skew-y:0;--hi-translate-x:0;--hi-translate-y:0;--hi-translate-z:0;--hi-transform:rotate(var(--hi-rotate)) scaleX(var(--hi-scale-x)) scaleY(var(--hi-scale-y)) scaleZ(var(--hi-scale-z)) skewX(var(--hi-skew-x)) skewY(var(--hi-skew-y)) translateX(var(--hi-translate-x)) translateY(var(--hi-translate-y)) translateZ(var(--hi-translate-z));}
+.scale-100{--hi-scale-x:1;--hi-scale-y:1;transform:var(--hi-transform);}"
 `;
 
 exports[`preset-mini > targets 1`] = `
@@ -467,13 +467,13 @@ exports[`preset-mini > targets 1`] = `
 .transition-property-width{transition-property:width;}
 .property-none{transition-property:none;}
 .transition-none{transition:none;}
-.transform,
+.origin-top-left{transform-origin:top left;}
 .-translate-full,
 .translate-full,
 .-translate-x-full,
 .-translate-y-1\\\\/2,
 .before\\\\:translate-y-full::before,
-.hover\\\\:translate-x-3,
+.hover\\\\:translate-x-3:hover,
 .peer:checked~.peer-checked\\\\:translate-x-\\\\[var\\\\(--reveal\\\\)\\\\],
 .translate-x-full,
 .translate-y-1\\\\/4,
@@ -491,36 +491,37 @@ exports[`preset-mini > targets 1`] = `
 .skew-y-\\\\[var\\\\(--skew-y\\\\)\\\\],
 .skew-y-10,
 .skew-y-10deg,
-.active\\\\:scale-4{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
-.origin-top-left{transform-origin:top left;}
-.-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;}
-.translate-full{--un-translate-x:100%;--un-translate-y:100%;}
-.-translate-x-full{--un-translate-x:-100%;}
-.-translate-y-1\\\\/2{--un-translate-y:-50%;}
-.before\\\\:translate-y-full::before{--un-translate-y:100%;}
-.hover\\\\:translate-x-3:hover{--un-translate-x:0.75rem;}
-.peer:checked~.peer-checked\\\\:translate-x-\\\\[var\\\\(--reveal\\\\)\\\\]{--un-translate-x:var(--reveal);}
-.translate-x-full{--un-translate-x:100%;}
-.translate-y-1\\\\/4{--un-translate-y:25%;}
-.translate-y-px{--un-translate-y:1px;}
-.-rotate-2{--un-rotate:-2deg;}
-.rotate-\\\\[var\\\\(--spin\\\\)\\\\]{--un-rotate:var(--spin);}
-.rotate-1deg{--un-rotate:1deg;}
-.skew-x-\\\\[var\\\\(--skew-x\\\\)\\\\]{--un-skew-x:var(--skew-x);}
+.active\\\\:scale-4:active,
+.transform{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+.-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;transform:var(--un-transform);}
+.translate-full{--un-translate-x:100%;--un-translate-y:100%;transform:var(--un-transform);}
+.-translate-x-full{--un-translate-x:-100%;transform:var(--un-transform);}
+.-translate-y-1\\\\/2{--un-translate-y:-50%;transform:var(--un-transform);}
+.before\\\\:translate-y-full::before{--un-translate-y:100%;transform:var(--un-transform);}
+.hover\\\\:translate-x-3:hover{--un-translate-x:0.75rem;transform:var(--un-transform);}
+.peer:checked~.peer-checked\\\\:translate-x-\\\\[var\\\\(--reveal\\\\)\\\\]{--un-translate-x:var(--reveal);transform:var(--un-transform);}
+.translate-x-full{--un-translate-x:100%;transform:var(--un-transform);}
+.translate-y-1\\\\/4{--un-translate-y:25%;transform:var(--un-transform);}
+.translate-y-px{--un-translate-y:1px;transform:var(--un-transform);}
+.-rotate-2{--un-rotate:-2deg;transform:var(--un-transform);}
+.rotate-\\\\[var\\\\(--spin\\\\)\\\\]{--un-rotate:var(--spin);transform:var(--un-transform);}
+.rotate-1deg{--un-rotate:1deg;transform:var(--un-transform);}
+.skew-x-\\\\[var\\\\(--skew-x\\\\)\\\\]{--un-skew-x:var(--skew-x);transform:var(--un-transform);}
 .skew-x-10,
 .skew-x-10\\\\.00deg,
-.skew-x-10deg{--un-skew-x:10deg;}
-.skew-x-10\\\\.01deg{--un-skew-x:10.01deg;}
-.skew-x-10\\\\.10deg{--un-skew-x:10.1deg;}
-.skew-x-10\\\\.11deg{--un-skew-x:10.11deg;}
-.skew-y-\\\\[var\\\\(--skew-y\\\\)\\\\]{--un-skew-y:var(--skew-y);}
+.skew-x-10deg{--un-skew-x:10deg;transform:var(--un-transform);}
+.skew-x-10\\\\.01deg{--un-skew-x:10.01deg;transform:var(--un-transform);}
+.skew-x-10\\\\.10deg{--un-skew-x:10.1deg;transform:var(--un-transform);}
+.skew-x-10\\\\.11deg{--un-skew-x:10.11deg;transform:var(--un-transform);}
+.skew-y-\\\\[var\\\\(--skew-y\\\\)\\\\]{--un-skew-y:var(--skew-y);transform:var(--un-transform);}
 .skew-y-10,
-.skew-y-10deg{--un-skew-y:10deg;}
-.active\\\\:scale-4:active{--un-scale-x:0.04;--un-scale-y:0.04;}
+.skew-y-10deg{--un-skew-y:10deg;transform:var(--un-transform);}
+.active\\\\:scale-4:active{--un-scale-x:0.04;--un-scale-y:0.04;transform:var(--un-transform);}
 .preserve-3d{transform-style:preserve-3d;}
 .preserve-flat{transform-style:flat;}
-.transform-gpu{transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translate3d(var(--un-translate-x), var(--un-translate-y), var(--un-translate-z));}
-.transform-cpu{transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+.transform{transform:var(--un-transform);}
+.transform-gpu{--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translate3d(var(--un-translate-x), var(--un-translate-y), var(--un-translate-z));}
+.transform-cpu{--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .transform-none{transform:none;}
 .will-change-auto{will-change:auto;}
 .will-change-margin\\\\2c padding{will-change:margin,padding;}
@@ -544,8 +545,8 @@ exports[`preset-mini > targets 1`] = `
 .motion-safe\\\\:transition{transition-property:color,background-color,border-color,text-decoration-color,fill,stroke,opacity,box-shadow,transform,filter,backdrop-filter;transition-timing-function:cubic-bezier(0.4,0,0.2,1);transition-duration:150ms;}
 }
 @media (prefers-reduced-motion: reduce){
-.motion-reduce\\\\:hover\\\\:translate-0{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
-.motion-reduce\\\\:hover\\\\:translate-0:hover{--un-translate-x:0rem;--un-translate-y:0rem;}
+.motion-reduce\\\\:hover\\\\:translate-0:hover{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
+.motion-reduce\\\\:hover\\\\:translate-0:hover{--un-translate-x:0rem;--un-translate-y:0rem;transform:var(--un-transform);}
 }
 @media print{
 .print\\\\:block{display:block;}

--- a/test/__snapshots__/shortcuts.test.ts.snap
+++ b/test/__snapshots__/shortcuts.test.ts.snap
@@ -8,7 +8,11 @@ exports[`shortcuts > dynamic 1`] = `
 
 exports[`shortcuts > merge transform-duplicated 1`] = `
 "/* layer: shortcuts */
-.transform-duplicated {
+.transform-duplicated,
+.transform-duplicated,
+.transform-duplicated,
+.transform-duplicated:hover,
+.transform-duplicated:active {
   --un-rotate: 0;
   --un-scale-x: 1;
   --un-scale-y: 1;
@@ -18,11 +22,14 @@ exports[`shortcuts > merge transform-duplicated 1`] = `
   --un-translate-x: 0;
   --un-translate-y: 0;
   --un-translate-z: 0;
-  transform: rotate(var(--un-rotate)) scaleX(var(--un-scale-x))
+  --un-transform: rotate(var(--un-rotate)) scaleX(var(--un-scale-x))
     scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x))
     skewY(var(--un-skew-y)) translateX(var(--un-translate-x))
     translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));
+}
+.transform-duplicated {
   --un-translate-x: 0.25rem;
+  transform: var(--un-transform);
   --un-translate-y: 0.5rem;
   --un-scale-x: 0.04;
   --un-scale-y: 0.04;
@@ -30,9 +37,11 @@ exports[`shortcuts > merge transform-duplicated 1`] = `
 .transform-duplicated:hover {
   --un-scale-x: 0.02;
   --un-scale-y: 0.02;
+  transform: var(--un-transform);
 }
 .transform-duplicated:active {
   --un-scale-x: 0.04;
+  transform: var(--un-transform);
 }
 "
 `;

--- a/test/__snapshots__/shortcuts.test.ts.snap
+++ b/test/__snapshots__/shortcuts.test.ts.snap
@@ -9,8 +9,6 @@ exports[`shortcuts > dynamic 1`] = `
 exports[`shortcuts > merge transform-duplicated 1`] = `
 "/* layer: shortcuts */
 .transform-duplicated,
-.transform-duplicated,
-.transform-duplicated,
 .transform-duplicated:hover,
 .transform-duplicated:active {
   --un-rotate: 0;

--- a/test/__snapshots__/shortcuts.test.ts.snap
+++ b/test/__snapshots__/shortcuts.test.ts.snap
@@ -8,10 +8,6 @@ exports[`shortcuts > dynamic 1`] = `
 
 exports[`shortcuts > merge transform-duplicated 1`] = `
 "/* layer: shortcuts */
-.transform-duplicated:hover {
-  --un-scale-x: 0.02;
-  --un-scale-y: 0.02;
-}
 .transform-duplicated {
   --un-rotate: 0;
   --un-scale-x: 1;
@@ -31,6 +27,10 @@ exports[`shortcuts > merge transform-duplicated 1`] = `
   --un-scale-x: 0.04;
   --un-scale-y: 0.04;
 }
+.transform-duplicated:hover {
+  --un-scale-x: 0.02;
+  --un-scale-y: 0.02;
+}
 .transform-duplicated:active {
   --un-scale-x: 0.04;
 }
@@ -39,9 +39,9 @@ exports[`shortcuts > merge transform-duplicated 1`] = `
 
 exports[`shortcuts > nesting static 1`] = `
 "/* layer: shortcuts */
+.btn2{margin:0.75rem;margin-left:2.5rem;margin-right:2.5rem;padding-left:0.5rem;padding-right:0.5rem;padding-top:0.75rem;padding-bottom:0.75rem;}
 .btn{margin-right:2.5rem;}
 .btn1{margin-left:2.5rem;margin-right:2.5rem;}
-.btn2{margin:0.75rem;margin-left:2.5rem;margin-right:2.5rem;padding-left:0.5rem;padding-right:0.5rem;padding-top:0.75rem;padding-bottom:0.75rem;}
 @media (min-width: 640px){
 .btn2{margin:0.5rem;}
 }"
@@ -49,8 +49,8 @@ exports[`shortcuts > nesting static 1`] = `
 
 exports[`shortcuts > static 1`] = `
 "/* layer: shortcuts */
-.sh3{margin:0.75rem;}
 .sh1{margin:0.75rem;padding-left:0.5rem;padding-right:0.5rem;padding-top:0.75rem;padding-bottom:0.75rem;}
+.sh3{margin:0.75rem;}
 .focus\\\\:sh2:focus,
 .sh2{font-size:0.875rem;line-height:1.25rem;font-size:1.125rem;line-height:1.75rem;}
 .focus\\\\:sh2:hover:focus,

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -31,7 +31,7 @@ describe('cli', () => {
       export default defineConfig({
         shortcuts: [{ box: 'max-w-7xl mx-auto bg-gray-100 rounded-md shadow-sm p-4' }]
       })
-    `,
+   `,
     })
 
     expect(output).toMatchSnapshot()

--- a/test/cli.test.ts
+++ b/test/cli.test.ts
@@ -31,7 +31,7 @@ describe('cli', () => {
       export default defineConfig({
         shortcuts: [{ box: 'max-w-7xl mx-auto bg-gray-100 rounded-md shadow-sm p-4' }]
       })
-   `,
+    `,
     })
 
     expect(output).toMatchSnapshot()


### PR DESCRIPTION
I haven't been following tailwind v2 internals closely, but at v3 its modifier classes (`transform`, `ring`, `filter`, etc.) does not provide the base css properties anymore (respectively: `transform`, `box-shadow`, `filter`, etc.) Instead, they define the variable versions (`--tw-transform`, `--tw-shadow`, `--tw-filter`, etc.), and then the base properties being moved to each modifiers.

Ex. previously: 
```css
.scale-2 {
  /* base transform styles */
  transform: var() /* combined vars. */;
}
.scale-2 {
  --tw-scale: 2;
}
```

now:
```css
.scale-2 {
  /* base transform styles */
  --tw-transform: var() /* combined vars. */;
}
.scale-2 {
  --tw-scale: 2;
  transform: var(--tw-transform);
}
```

While this is trivial to implement in normal rules, it becomes tricky to do in shortcut, as currently shortcuts get the merged properties of its definitions.

My proposed solution is to resolve shortcut definition individually like regular rules, so the orders are preserved. One drawback to this method is duplicated selector for each shortcut due to the css properties aren't merged.