### PR TITLE
refactor(preset-mini): text-size prioritize theme

### DIFF
--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -22,18 +22,16 @@ export const fonts: Rule<Theme>[] = [
 
   // size
   [/^text-(.+)$/, ([, s = 'base'], { theme }) => {
-    const size = h.bracket.auto.rem(s)
-    if (size)
-      return { 'font-size': size }
-
     const themed = toArray(theme.fontSize?.[s])
     if (themed?.[0]) {
-      const [size, height] = themed
+      const [size, height = '1'] = themed
       return {
         'font-size': size,
         'line-height': height,
       }
     }
+
+    return { 'font-size': h.bracket.auto.rem(s) }
   }],
   [/^text-size-(.+)$/, ([, s]) => ({ 'font-size': h.bracket.auto.rem(s) })],
 

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -142,9 +142,10 @@ exports[`preset-mini > targets 1`] = `
 .peer:is(:placeholder-shown)~.peer-is-placeholder-shown\\\\:text-3xl,
 .peer:not(:placeholder-shown)~.peer-not-placeholder-shown\\\\:text-3xl{font-size:1.875rem;line-height:2.25rem;}
 .peer:not(:placeholder-shown)~.peer-not-placeholder-shown\\\\:text-2xl{font-size:1.5rem;line-height:2rem;}
+.text-2em,
+.text-size-\\\\[2em\\\\]{font-size:2em;}
 .text-base{font-size:1rem;line-height:1.5rem;}
 .text-lg{font-size:1.125rem;line-height:1.75rem;}
-.text-size-\\\\[2em\\\\]{font-size:2em;}
 .font-thin{font-weight:100;}
 .fw-900{font-weight:900;}
 .leading-2{line-height:0.5rem;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -451,6 +451,7 @@ export const presetMiniTargets: string[] = [
   'text-4xl',
   'text-base',
   'text-lg',
+  'text-2em',
   'text-size-[2em]',
   'font-thin',
   'fw-900',


### PR DESCRIPTION
Related: #223, #218. 

Since font-size can now be targetted via `text-size-x`, the old behavior prioritizing theme for `text-x` can be restored.