### PR TITLE
feat(preset-mini): add perspective utilities

### DIFF
--- a/packages/preset-mini/src/rules/transform.ts
+++ b/packages/preset-mini/src/rules/transform.ts
@@ -33,6 +33,28 @@ export const transforms: Rule[] = [
   // skip 1 & 2 letters shortcut
   [/^origin-([-\w]{3,})$/, ([, s]) => ({ 'transform-origin': positionMap[s] })],
 
+  // perspectives
+  [/^perspect-(.+)$/, ([, s]) => {
+    const v = h.px.numberWithUnit(s)
+    if (v != null) {
+      return {
+        '-webkit-perspective': v,
+        'perspective': v,
+      }
+    }
+  }],
+
+  // skip 1 & 2 letters shortcut
+  [/^perspect-origin-(.+)$/, ([, s]) => {
+    const v = h.bracket(s) ?? (s.length >= 3 ? positionMap[s] : undefined)
+    if (v != null) {
+      return {
+        '-webkit-perspective-origin': v,
+        'perspective-origin': v,
+      }
+    }
+  }],
+
   // modifiers
   [/^translate-()(.+)$/, handleTranslate],
   [/^translate-([xyz])-(.+)$/, handleTranslate],

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -493,6 +493,13 @@ exports[`preset-mini > targets 1`] = `
 .skew-y-10deg,
 .active\\\\:scale-4{--un-rotate:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;transform:rotate(var(--un-rotate)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z));}
 .origin-top-left{transform-origin:top left;}
+.perspect-100{-webkit-perspective:100px;perspective:100px;}
+.perspect-23rem{-webkit-perspective:23rem;perspective:23rem;}
+.perspect-800px{-webkit-perspective:800px;perspective:800px;}
+.perspect-origin-\\\\[150\\\\%_150\\\\%\\\\]{-webkit-perspective-origin:150% 150%;perspective-origin:150% 150%;}
+.perspect-origin-\\\\[150\\\\%\\\\]{-webkit-perspective-origin:150%;perspective-origin:150%;}
+.perspect-origin-center{-webkit-perspective-origin:center;perspective-origin:center;}
+.perspect-origin-top-right{-webkit-perspective-origin:top right;perspective-origin:top right;}
 .-translate-full{--un-translate-x:-100%;--un-translate-y:-100%;}
 .translate-full{--un-translate-x:100%;--un-translate-y:100%;}
 .-translate-x-full{--un-translate-x:-100%;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -423,6 +423,13 @@ export const presetMiniTargets: string[] = [
   'preserve-3d',
   'preserve-flat',
   'origin-top-left',
+  'perspect-100',
+  'perspect-800px',
+  'perspect-23rem',
+  'perspect-origin-center',
+  'perspect-origin-top-right',
+  'perspect-origin-[150%]',
+  'perspect-origin-[150%_150%]',
 
   // transition
   'transition-none',


### PR DESCRIPTION
If this should be on `preset-wind`, I propose moving `preserve-3d` and `preserve-flat` too.
