### PR TITLE
feat(svelte-scoped): scoped css mode for svelte

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ That's it, have fun.
 See [all packages](https://github.com/antfu/unocss/tree/main/packages).
 
 Refer to the full documentation on [Vite](https://github.com/antfu/unocss/blob/main/packages/vite/README.md): 
-- modes: `global`, `dist-chunk`, `per-module`, `vue-scoped`, and `shadow-dom`.
+- modes: `global`, `dist-chunk`, `per-module`, `vue-scoped`, `svelte-scoped`, and `shadow-dom`.
 - frameworks: `React`, `Preact`, `Svelte`, `SvelteKit`, `Web Components` and `Solid`.
 
 ### Nuxt

--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -44,6 +44,10 @@ The generated `css` will be a global stylesheet injected on the `index.html`.
 
 This mode will inject generated CSS to Vue SFC's `<style scoped>` for isolation.
 
+### svelte-scoped (WIP)
+
+This mode will inject generated CSS to Svelte's `<style>` for isolation.
+
 ### per-module (WIP)
 
 This mode will generate a CSS sheet for each module, can be scoped.

--- a/packages/vite/src/index.ts
+++ b/packages/vite/src/index.ts
@@ -6,6 +6,7 @@ import { ChunkModeBuildPlugin } from './modes/chunk-build'
 import { GlobalModeDevPlugin, GlobalModePlugin } from './modes/global'
 import { PerModuleModePlugin } from './modes/per-module'
 import { VueScopedPlugin } from './modes/vue-scoped'
+import { SvelteScopedPlugin } from './modes/svelte-scoped'
 import { ShadowDomModuleModePlugin } from './modes/shadow-dom'
 import { ConfigHMRPlugin } from './config-hmr'
 import type { VitePluginConfig } from './types'
@@ -15,6 +16,7 @@ export * from './modes/chunk-build'
 export * from './modes/global'
 export * from './modes/per-module'
 export * from './modes/vue-scoped'
+export * from './modes/svelte-scoped'
 
 export type { UnocssPluginContext } from '../../plugins-common'
 
@@ -42,6 +44,9 @@ export default function UnocssPlugin(
   }
   else if (mode === 'vue-scoped') {
     plugins.push(VueScopedPlugin(ctx))
+  }
+  else if (mode === 'svelte-scoped') {
+    plugins.push(SvelteScopedPlugin(ctx))
   }
   else if (mode === 'shadow-dom') {
     plugins.push(ShadowDomModuleModePlugin(ctx))

--- a/packages/vite/src/modes/svelte-scoped.ts
+++ b/packages/vite/src/modes/svelte-scoped.ts
@@ -1,0 +1,41 @@
+import type { Plugin } from 'vite'
+import { createFilter } from '@rollup/pluginutils'
+import type { UnocssPluginContext } from '../../../plugins-common'
+import { defaultExclude } from '../../../plugins-common'
+
+export function SvelteScopedPlugin({ uno, ready }: UnocssPluginContext): Plugin {
+  let filter = createFilter([/\.svelte$/], defaultExclude)
+
+  async function transformSFC(code: string) {
+    const { css } = await uno.generate(code)
+    if (!css)
+      return null
+    return `${code}\n<style>${css}</style>`
+  }
+
+  return {
+    name: 'unocss:svelte-scoped',
+    enforce: 'pre',
+    async configResolved() {
+      const { config } = await ready
+      filter = createFilter(
+        config.include || [/\.svelte$/],
+        config.exclude || defaultExclude,
+      )
+    },
+    transform(code, id) {
+      if (!filter(id))
+        return
+      return transformSFC(code)
+    },
+    handleHotUpdate(ctx) {
+      const read = ctx.read
+      if (filter(ctx.file)) {
+        ctx.read = async() => {
+          const code = await read()
+          return await transformSFC(code) || code
+        }
+      }
+    },
+  }
+}

--- a/packages/vite/src/types.ts
+++ b/packages/vite/src/types.ts
@@ -15,9 +15,10 @@ export interface VitePluginConfig<Theme extends {} = {}> extends UserConfig<Them
    * - `dist-chunk` - generate a CSS sheet for each code chunk on build, great for MPA
    * - `per-module` - generate a CSS sheet for each module, can be scoped
    * - `vue-scoped` - inject generated CSS to Vue SFC's `<style scoped>` for isolation
+   * - `svelte-scoped` - inject generated CSS to Svelte's `<style>` for isolation
    * - `shadow-dom` - inject generated CSS to `Shadow DOM` css style block for each web component
    *
    * @default 'global'
    */
-  mode?: 'global' | 'per-module' | 'vue-scoped' | 'dist-chunk' | 'shadow-dom'
+  mode?: 'global' | 'per-module' | 'vue-scoped' | 'svelte-scoped' | 'dist-chunk' | 'shadow-dom'
 }


### PR DESCRIPTION
This works for building css scoped svelte components. It is an almost direct copy of the vue scoped mode.