### PR TITLE
update Sveltekit config requirements

### DIFF
--- a/packages/vite/README.md
+++ b/packages/vite/README.md
@@ -215,20 +215,12 @@ You can use simple rules with `class:`, for example `class:bg-red-500={foo}` or 
 
 ```ts
 // svelte.config.js
-import preprocess from 'svelte-preprocess'
 import UnoCss from 'unocss/vite'
 import { extractorSvelte } from '@unocss/core'
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
-  // Consult https://github.com/sveltejs/svelte-preprocess
-  // for more information about preprocessors
-  preprocess: preprocess(),
-
   kit: {
-
-    // hydrate the <div id="svelte"> element in src/app.html
-    target: '#svelte',
     vite: {
       plugins: [
         UnoCss({


### PR DESCRIPTION
Apparently, ``svelte-preprocess`` is not required for UnoCSS. 
I have tested a build without it. Everything works as usual, even the class directives. Just the extractor is enough.

Also, ``target: '#svelte'`` is optional in Sveltekit. Sveltekit uses body of the app if no target is present. 
So I think it isn't necessary to show it in here.