### PR TITLE
feat(core): `noMerge` rule meta

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -180,18 +180,18 @@ export class UnoGenerator {
           const sorted = items
             .filter(i => (i[4]?.layer || 'default') === layer)
             .sort((a, b) => a[0] - b[0] || a[1]?.localeCompare(b[1] || '') || 0)
-            .map(a => [a[1] ? applyScope(a[1], scope) : a[1], a[2]])
-            .map(a => [a[0] == null ? a[0] : [a[0]], a[1]]) as [string[] | undefined, string][]
+            .map(a => [a[1] ? applyScope(a[1], scope) : a[1], a[2], !!a[4]?.splitSelector])
+            .map(a => [a[0] == null ? a[0] : [a[0]], a[1], a[2]]) as [string[] | undefined, string, boolean][]
           if (!sorted.length)
             return undefined
           const rules = sorted
             .reverse()
-            .map(([selector, body], idx) => {
+            .map(([selector, body, splitSelector], idx) => {
               if (selector && this.config.mergeSelectors) {
                 // search for rules that has exact same body, and merge them
                 for (let i = idx + 1; i < size; i++) {
                   const current = sorted[i]
-                  if (current && current[0] && current[1] === body) {
+                  if (!splitSelector && current && current[0] && current[1] === body) {
                     current[0].push(...selector)
                     return null
                   }

--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -180,18 +180,18 @@ export class UnoGenerator {
           const sorted = items
             .filter(i => (i[4]?.layer || 'default') === layer)
             .sort((a, b) => a[0] - b[0] || a[1]?.localeCompare(b[1] || '') || 0)
-            .map(a => [a[1] ? applyScope(a[1], scope) : a[1], a[2], !!a[4]?.splitSelector])
+            .map(a => [a[1] ? applyScope(a[1], scope) : a[1], a[2], !!a[4]?.noMerge])
             .map(a => [a[0] == null ? a[0] : [a[0]], a[1], a[2]]) as [string[] | undefined, string, boolean][]
           if (!sorted.length)
             return undefined
           const rules = sorted
             .reverse()
-            .map(([selector, body, splitSelector], idx) => {
+            .map(([selector, body, noMerge], idx) => {
               if (selector && this.config.mergeSelectors) {
                 // search for rules that has exact same body, and merge them
                 for (let i = idx + 1; i < size; i++) {
                   const current = sorted[i]
-                  if (!splitSelector && current && current[0] && current[1] === body) {
+                  if (!noMerge && current && current[0] && current[1] === body) {
                     current[0].push(...selector)
                     return null
                   }

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -110,7 +110,7 @@ export interface RuleMeta {
    * Option to not merge this selector even if the body are the same.
    * @default false
    */
-  splitSelector?: boolean
+  noMerge?: boolean
   /**
    * Internal rules will only be matched for shortcuts but not the user code.
    * @default false

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -107,6 +107,11 @@ export interface RuleMeta {
    */
   layer?: string
   /**
+   * Option to not merge this selector even if the body are the same.
+   * @default false
+   */
+  splitSelector?: boolean
+  /**
    * Internal rules will only be matched for shortcuts but not the user code.
    * @default false
    */

--- a/test/__snapshots__/selector-no-merge.test.ts.snap
+++ b/test/__snapshots__/selector-no-merge.test.ts.snap
@@ -1,0 +1,14 @@
+// Vitest Snapshot v1
+
+exports[`selector > rules split selector 1`] = `
+"/* layer: default */
+.to-merge,
+.merge-candidate{merged:1;}
+.not-merged{merged:1;}"
+`;
+
+exports[`variant > variant split selector 1`] = `
+"/* layer: default */
+.moz\\\\:no-merge::non-breaking{merged:1;}
+.webkit\\\\:no-merge::breaking{merged:1;}"
+`;

--- a/test/selector-no-merge.test.ts
+++ b/test/selector-no-merge.test.ts
@@ -1,0 +1,35 @@
+import { createGenerator } from '@unocss/core'
+import { variantMatcher } from '@unocss/preset-mini/utils'
+import { describe, expect, test } from 'vitest'
+
+describe('selector', () => {
+  const uno = createGenerator({
+    rules: [
+      [/^to-merge$/, () => [{ merged: 1 }]],
+      [/^merge-candidate$/, () => ({ merged: 1 })],
+      [/^not-merged$/, () => ({ merged: 1 }), { splitSelector: true }],
+    ],
+  })
+
+  test('rules split selector', async() => {
+    const { css } = await uno.generate('to-merge merge-candidate not-merged')
+    expect(css).toMatchSnapshot()
+  })
+})
+
+describe('variant', () => {
+  const uno = createGenerator({
+    variants: [
+      variantMatcher('moz', s => `${s}::non-breaking`),
+      variantMatcher('webkit', s => `${s}::breaking`),
+    ],
+    rules: [
+      [/^no-merge$/, () => ({ merged: 1 }), { splitSelector: true }],
+    ],
+  })
+
+  test('variant split selector', async() => {
+    const { css } = await uno.generate('moz:no-merge webkit:no-merge')
+    expect(css).toMatchSnapshot()
+  })
+})

--- a/test/selector-no-merge.test.ts
+++ b/test/selector-no-merge.test.ts
@@ -7,7 +7,7 @@ describe('selector', () => {
     rules: [
       [/^to-merge$/, () => [{ merged: 1 }]],
       [/^merge-candidate$/, () => ({ merged: 1 })],
-      [/^not-merged$/, () => ({ merged: 1 }), { splitSelector: true }],
+      [/^not-merged$/, () => ({ merged: 1 }), { noMerge: true }],
     ],
   })
 
@@ -24,7 +24,7 @@ describe('variant', () => {
       variantMatcher('webkit', s => `${s}::breaking`),
     ],
     rules: [
-      [/^no-merge$/, () => ({ merged: 1 }), { splitSelector: true }],
+      [/^no-merge$/, () => ({ merged: 1 }), { noMerge: true }],
     ],
   })
 


### PR DESCRIPTION
See https://www.w3.org/TR/selectors-3/#grouping

Mostly for safely using prefixed pseudo element (via variant).