### PR TITLE
feat(preset-mini): add colored shadow opacity

### DIFF
--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,6 +1,6 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
-import { parseColor } from '../utils'
+import { handler as h, parseColor } from '../utils'
 import { varEmpty } from './static'
 
 const shadowColorResolver = (body: string, theme: Theme) => {
@@ -9,15 +9,23 @@ const shadowColorResolver = (body: string, theme: Theme) => {
   if (!data)
     return
 
-  const { color, rgba } = data
+  const { alpha, opacity, color, rgba } = data
 
   if (!color)
     return
 
   if (rgba) {
-    // shadow opacity ignored
-    return {
-      '--un-shadow-color': `${rgba.slice(0, 3).join(',')}`,
+    if (alpha != null) {
+      return {
+        '--un-shadow-opacity': rgba[3],
+        '--un-shadow-color': rgba.slice(0, 3).join(','),
+      }
+    }
+    else {
+      return {
+        '--un-shadow-opacity': (opacity && h.cssvar(opacity)) ?? 1,
+        '--un-shadow-color': rgba.join(','),
+      }
     }
   }
   else {
@@ -40,5 +48,6 @@ export const boxShadows: Rule<Theme>[] = [
     }
   }],
   [/^shadow-(.+)$/, ([, d], { theme }) => shadowColorResolver(d, theme)],
+  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent.cssvar(opacity) })],
   ['shadow-inset', { '--un-shadow-inset': 'inset' }],
 ]

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -20,12 +20,12 @@ export const borderRadius = {
 }
 
 export const boxShadow = {
-  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1)',
-  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05)',
-  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 2px 4px -2px rgba(var(--un-shadow-color), 0.1)',
-  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 4px 6px -4px rgba(var(--un-shadow-color), 0.1)',
-  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1)',
-  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), 0.25)',
-  'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), 0.05)',
+  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
+  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05))',
+  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 2px 4px -2px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
+  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 4px 6px -4px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
+  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
+  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.25))',
+  'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05))',
   'none': '0 0 #0000',
 }

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -8,5 +8,5 @@ exports[`cli > builds uno.css 1`] = `
 
 exports[`cli > supports unocss.config.js 1`] = `
 "/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
+.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
 `;

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -266,12 +266,14 @@ exports[`preset-mini > targets 1`] = `
 .text-opacity-\\\\[13\\\\.3333333\\\\%\\\\]{--un-text-opacity:13.3333333%;}
 .italic{font-style:italic;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:grayscale;}
-.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-none{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:0 0 #0000;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-current{--un-shadow-color:currentColor;}
-.shadow-green-500{--un-shadow-color:34,197,94;}
+.shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:34,197,94;}
+.shadow-green-900\\\\/50{--un-shadow-opacity:0.5;--un-shadow-color:20,83,45;}
 .shadow-transparent{--un-shadow-color:transparent;}
+.shadow-op-50{--un-shadow-opacity:0.5;}
 .shadow-inset{--un-shadow-inset:inset;}
 .ring{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
 .ring-10{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -287,6 +287,8 @@ export const presetMiniTargets: string[] = [
   'shadow-none',
   'shadow-xl',
   'shadow-green-500',
+  'shadow-green-900/50',
+  'shadow-op-50',
   'shadow-inset',
 
   // size


### PR DESCRIPTION
This PR aligns the shadow color behavior to tailwind: colored shadow get full opacity by default. Tw's shadow actually parses the shadow theme and uses SHORTCUT_NO_MERGE-like rule, which is not the case with this implementation.

Without parsing, the usable colors are limited to only hex colors, due to shadow colors dependant on rgb array.

See alternative PR #450 with simple parsing support.