### PR TITLE
feat(preset-mini): add text-shadow shadow color & opacity

### DIFF
--- a/packages/preset-mini/src/rules/typography.ts
+++ b/packages/preset-mini/src/rules/typography.ts
@@ -1,4 +1,4 @@
-import type { Rule } from '@unocss/core'
+import type { CSSObject, Rule } from '@unocss/core'
 import { toArray } from '@unocss/core'
 import type { Theme } from '../theme'
 import { colorResolver, handler as h } from '../utils'
@@ -75,5 +75,29 @@ export const textStrokes: Rule<Theme>[] = [
 ]
 
 export const textShadows: Rule<Theme>[] = [
-  [/^text-shadow(?:-(.+))?$/, ([, s], { theme }) => ({ 'text-shadow': theme.textShadow?.[s || 'DEFAULT'] || h.bracket.cssvar(s) })],
+  [/^text-shadow(?:-(.+))?$/, ([, s], { theme }) => {
+    const v = theme.textShadow?.[s || 'DEFAULT']
+    if (v != null) {
+      const shadow = toArray(v)
+      const colored = shadow.map(s => s.replace(/\s\S+$/, ' var(--un-text-shadow-color)'))
+      return {
+        '--un-text-shadow': shadow.join(','),
+        '--un-text-shadow-colored': colored.join(','),
+        'text-shadow': 'var(--un-text-shadow)',
+      }
+    }
+    return { 'text-shadow': h.bracket.cssvar(s) }
+  }],
+
+  // colors
+  [/^text-shadow-color-(.+)$/, (m, ctx) => {
+    const color = colorResolver('--un-text-shadow-color', 'text-shadow')(m, ctx) as CSSObject | undefined
+    if (color) {
+      return {
+        ...color,
+        '--un-text-shadow': 'var(--un-text-shadow-colored)',
+      }
+    }
+  }],
+  [/^text-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-shadow-opacity': h.bracket.percent(opacity) })],
 ]

--- a/packages/preset-mini/src/theme/font.ts
+++ b/packages/preset-mini/src/theme/font.ts
@@ -73,7 +73,7 @@ export const textStrokeWidth: Theme['textStrokeWidth'] = {
 }
 
 export const textShadow: Theme['textShadow'] = {
-  DEFAULT: ['0 0 1px rgba(0,0,0,0.2)', '0 0 1pxrgba(1,0,5,0.1)'],
+  DEFAULT: ['0 0 1px rgba(0,0,0,0.2)', '0 0 1px rgba(1,0,5,0.1)'],
   sm: '1px 1px 3px rgba(36,37,47,0.25)',
   md: ['0 1px 2px rgba(30,29,39,0.19)', '1px 2px 4px rgba(54,64,147,0.18)'],
   lg: ['3px 3px 6px rgba(0,0,0,0.26)', '0 0 5px rgba(15,3,86,0.22)'],

--- a/packages/preset-mini/src/theme/font.ts
+++ b/packages/preset-mini/src/theme/font.ts
@@ -73,12 +73,12 @@ export const textStrokeWidth: Theme['textStrokeWidth'] = {
 }
 
 export const textShadow: Theme['textShadow'] = {
-  DEFAULT: '0px 0px 1px rgb(0 0 0/20%), 0px 0px 1px rgb(1 0 5/10%)',
-  sm: '1px 1px 3px rgb(36 37 47 / 25%)',
-  md: '0px 1px 2px rgb(30 29 39 / 19%), 1px 2px 4px rgb(54 64 147 / 18%)',
-  lg: '3px 3px 6px rgb(0 0 0 / 26%), 0px 0px 5px rgb(15 3 86 / 22%)',
-  xl: '1px 1px 3px rgb(0 0 0 / 29%), 2px 4px 7px rgb(73 64 125 / 35%)',
-  none: 'none',
+  DEFAULT: ['0 0 1px rgba(0,0,0,0.2)', '0 0 1pxrgba(1,0,5,0.1)'],
+  sm: '1px 1px 3px rgba(36,37,47,0.25)',
+  md: ['0 1px 2px rgba(30,29,39,0.19)', '1px 2px 4px rgba(54,64,147,0.18)'],
+  lg: ['3px 3px 6px rgba(0,0,0,0.26)', '0 0 5px rgba(15,3,86,0.22)'],
+  xl: ['1px 1px 3px rgba(0,0,0,0.29)', '2px 4px 7px rgba(73,64,125,0.35)'],
+  none: '0 0 #0000',
 }
 
 export const lineHeight: Theme['lineHeight'] = {

--- a/packages/preset-mini/src/theme/types.ts
+++ b/packages/preset-mini/src/theme/types.ts
@@ -22,7 +22,7 @@ export interface Theme {
   wordSpacing?: Record<string, string>
   boxShadow?: Record<string, string>
   textIndent?: Record<string, string>
-  textShadow?: Record<string, string>
+  textShadow?: Record<string, string | string[]>
   textStrokeWidth?: Record<string, string>
   // filters
   blur?: Record<string, string>

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -190,7 +190,7 @@ exports[`preset-mini > targets 1`] = `
 .text-stroke-sm{-webkit-text-stroke-width:thin;}
 .text-stroke-blue-500{--un-text-stroke-opacity:1;-webkit-text-stroke-color:rgba(59,130,246,var(--un-text-stroke-opacity));}
 .text-stroke-op-60{--un-text-stroke-opacity:0.6;}
-.text-shadow{--un-text-shadow:0 0 1px rgba(0,0,0,0.2),0 0 1pxrgba(1,0,5,0.1);--un-text-shadow-colored:0 0 1px var(--un-text-shadow-color),0 0 var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
+.text-shadow{--un-text-shadow:0 0 1px rgba(0,0,0,0.2),0 0 1px rgba(1,0,5,0.1);--un-text-shadow-colored:0 0 1px var(--un-text-shadow-color),0 0 1px var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
 .text-shadow-\\\\$var{text-shadow:var(--var);}
 .text-shadow-lg{--un-text-shadow:3px 3px 6px rgba(0,0,0,0.26),0 0 5px rgba(15,3,86,0.22);--un-text-shadow-colored:3px 3px 6px var(--un-text-shadow-color),0 0 5px var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
 .text-shadow-none{--un-text-shadow:0 0 #0000;--un-text-shadow-colored:0 0 var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -190,11 +190,11 @@ exports[`preset-mini > targets 1`] = `
 .text-stroke-sm{-webkit-text-stroke-width:thin;}
 .text-stroke-blue-500{--un-text-stroke-opacity:1;-webkit-text-stroke-color:rgba(59,130,246,var(--un-text-stroke-opacity));}
 .text-stroke-op-60{--un-text-stroke-opacity:0.6;}
-.text-shadow{--un-text-shadow:text-shadow(0 0 1px rgba(0,0,0,0.2)) text-shadow(0 0 1pxrgba(1,0,5,0.1));--un-text-shadow-colored:text-shadow(0 0 1px var(--un-text-shadow-color)) text-shadow(0 0 var(--un-text-shadow-color));text-shadow:0 0 1px rgba(0,0,0,0.2),0 0 1pxrgba(1,0,5,0.1);}
+.text-shadow{--un-text-shadow:0 0 1px rgba(0,0,0,0.2),0 0 1pxrgba(1,0,5,0.1);--un-text-shadow-colored:0 0 1px var(--un-text-shadow-color),0 0 var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
 .text-shadow-\\\\$var{text-shadow:var(--var);}
-.text-shadow-lg{--un-text-shadow:text-shadow(3px 3px 6px rgba(0,0,0,0.26)) text-shadow(0 0 5px rgba(15,3,86,0.22));--un-text-shadow-colored:text-shadow(3px 3px 6px var(--un-text-shadow-color)) text-shadow(0 0 5px var(--un-text-shadow-color));text-shadow:3px 3px 6px rgba(0,0,0,0.26),0 0 5px rgba(15,3,86,0.22);}
-.text-shadow-none{--un-text-shadow:text-shadow(0 0 #0000);--un-text-shadow-colored:text-shadow(0 0 var(--un-text-shadow-color));text-shadow:0 0 #0000;}
-.text-shadow-color-red-300{--un-text-shadow-opacity:1;-un-text-shadow-color:rgba(252,165,165,var(--un-text-shadow-opacity));}
+.text-shadow-lg{--un-text-shadow:3px 3px 6px rgba(0,0,0,0.26),0 0 5px rgba(15,3,86,0.22);--un-text-shadow-colored:3px 3px 6px var(--un-text-shadow-color),0 0 5px var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
+.text-shadow-none{--un-text-shadow:0 0 #0000;--un-text-shadow-colored:0 0 var(--un-text-shadow-color);text-shadow:var(--un-text-shadow);}
+.text-shadow-color-red-300{--un-text-shadow-opacity:1;--un-text-shadow-color:rgba(252,165,165,var(--un-text-shadow-opacity));--un-text-shadow:var(--un-text-shadow-colored);}
 .text-shadow-color-op-30{--un-text-shadow-opacity:0.3;}
 .case-upper{text-transform:uppercase;}
 .case-normal{text-transform:none;}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -190,10 +190,12 @@ exports[`preset-mini > targets 1`] = `
 .text-stroke-sm{-webkit-text-stroke-width:thin;}
 .text-stroke-blue-500{--un-text-stroke-opacity:1;-webkit-text-stroke-color:rgba(59,130,246,var(--un-text-stroke-opacity));}
 .text-stroke-op-60{--un-text-stroke-opacity:0.6;}
-.text-shadow{text-shadow:0px 0px 1px rgb(0 0 0/20%), 0px 0px 1px rgb(1 0 5/10%);}
+.text-shadow{--un-text-shadow:text-shadow(0 0 1px rgba(0,0,0,0.2)) text-shadow(0 0 1pxrgba(1,0,5,0.1));--un-text-shadow-colored:text-shadow(0 0 1px var(--un-text-shadow-color)) text-shadow(0 0 var(--un-text-shadow-color));text-shadow:0 0 1px rgba(0,0,0,0.2),0 0 1pxrgba(1,0,5,0.1);}
 .text-shadow-\\\\$var{text-shadow:var(--var);}
-.text-shadow-lg{text-shadow:3px 3px 6px rgb(0 0 0 / 26%), 0px 0px 5px rgb(15 3 86 / 22%);}
-.text-shadow-none{text-shadow:none;}
+.text-shadow-lg{--un-text-shadow:text-shadow(3px 3px 6px rgba(0,0,0,0.26)) text-shadow(0 0 5px rgba(15,3,86,0.22));--un-text-shadow-colored:text-shadow(3px 3px 6px var(--un-text-shadow-color)) text-shadow(0 0 5px var(--un-text-shadow-color));text-shadow:3px 3px 6px rgba(0,0,0,0.26),0 0 5px rgba(15,3,86,0.22);}
+.text-shadow-none{--un-text-shadow:text-shadow(0 0 #0000);--un-text-shadow-colored:text-shadow(0 0 var(--un-text-shadow-color));text-shadow:0 0 #0000;}
+.text-shadow-color-red-300{--un-text-shadow-opacity:1;-un-text-shadow-color:rgba(252,165,165,var(--un-text-shadow-opacity));}
+.text-shadow-color-op-30{--un-text-shadow-opacity:0.3;}
 .case-upper{text-transform:uppercase;}
 .case-normal{text-transform:none;}
 .group:focus:hover .group-hover\\\\:group-focus\\\\:text-center{text-align:center;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -495,6 +495,8 @@ export const presetMiniTargets: string[] = [
   'text-shadow-lg',
   'text-shadow-none',
   'text-shadow-$var',
+  'text-shadow-color-red-300',
+  'text-shadow-color-op-30',
 
   // variables
   'bg-$test-variable',


### PR DESCRIPTION
The logic for #450, but for `text-shadow`; also without inset processing.