### PR TITLE
refactor(preset-mini): update colored shadow rule

### DIFF
--- a/packages/preset-mini/src/rules/ring.ts
+++ b/packages/preset-mini/src/rules/ring.ts
@@ -1,22 +1,30 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
 import { colorResolver, handler as h } from '../utils'
+import { shadowBase } from './shadow'
 import { varEmpty } from './static'
+
+const ringBase = {
+  '--un-ring-inset': varEmpty,
+  '--un-ring-offset-width': '0px',
+  '--un-ring-offset-color': '#fff',
+  '--un-ring-color': 'rgba(147,197,253,0.5)',
+  ...shadowBase,
+}
 
 export const rings: Rule<Theme>[] = [
   // size
   [/^ring(?:-(.+))?$/, ([, d]) => {
     const value = h.px(d || '1')
     if (value) {
-      return {
-        '--un-ring-inset': varEmpty,
-        '--un-ring-offset-width': '0px',
-        '--un-ring-offset-color': '#fff',
-        '--un-ring-color': 'rgba(147, 197, 253, .5)',
-        '--un-ring-offset-shadow': 'var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color)',
-        '--un-ring-shadow': `var(--un-ring-inset) 0 0 0 calc(${value} + var(--un-ring-offset-width)) var(--un-ring-color)`,
-        'box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
-      }
+      return [
+        ringBase,
+        {
+          '--un-ring-offset-shadow': 'var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color)',
+          '--un-ring-shadow': `var(--un-ring-inset) 0 0 0 calc(${value} + var(--un-ring-offset-width)) var(--un-ring-color)`,
+          'box-shadow': 'var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000)',
+        },
+      ]
     }
   }],
 

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,44 +1,47 @@
-import type { Rule } from '@unocss/core'
+import type { CSSObject, Rule } from '@unocss/core'
+import { CONTROL_SHORTCUT_NO_MERGE, toArray } from '@unocss/core'
 import type { Theme } from '../theme'
-import { parseColor } from '../utils'
+import { colorResolver, handler as h } from '../utils'
 import { varEmpty } from './static'
 
-const shadowColorResolver = (body: string, theme: Theme) => {
-  const data = parseColor(body, theme)
-
-  if (!data)
-    return
-
-  const { color, rgba } = data
-
-  if (!color)
-    return
-
-  if (rgba) {
-    // shadow opacity ignored
-    return {
-      '--un-shadow-color': `${rgba.slice(0, 3).join(',')}`,
-    }
-  }
-  else {
-    return {
-      '--un-shadow-color': color,
-    }
-  }
+export const shadowBase = {
+  [CONTROL_SHORTCUT_NO_MERGE]: '',
+  '--un-ring-offset-shadow': '0 0 #0000',
+  '--un-ring-shadow': '0 0 #0000',
+  '--un-shadow-inset': varEmpty,
+  '--un-shadow': '0 0 #0000',
+  '--un-shadow-colored': '0 0 #0000',
 }
 
 export const boxShadows: Rule<Theme>[] = [
   [/^shadow(?:-(.+))?$/, ([, d], { theme }) => {
-    const value = theme.boxShadow?.[d || 'DEFAULT']
-    if (value) {
+    const v = theme.boxShadow?.[d || 'DEFAULT']
+    if (v) {
+      const shadow = toArray(v)
+      const colored = shadow.map(s => s.replace(/\s\S+$/, ' var(--un-shadow-color)'))
+      return [
+        shadowBase,
+        {
+          '--un-shadow': shadow.join(','),
+          '--un-shadow-colored': colored.join(','),
+          'box-shadow': 'var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow)',
+        },
+      ]
+    }
+  }],
+
+  // color
+  [/^shadow-(.+)$/, (m, ctx) => {
+    const color = colorResolver('--un-shadow-color', 'shadow')(m, ctx) as CSSObject | undefined
+    if (color) {
       return {
-        '--un-shadow-inset': varEmpty,
-        '--un-shadow-color': '0,0,0',
-        '--un-shadow': value,
-        'box-shadow': 'var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow)',
+        ...color,
+        '--un-shadow': 'var(--un-shadow-colored)',
       }
     }
   }],
-  [/^shadow-(.+)$/, ([, d], { theme }) => shadowColorResolver(d, theme)],
+  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent.cssvar(opacity) })],
+
+  // inset
   ['shadow-inset', { '--un-shadow-inset': 'inset' }],
 ]

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -1,6 +1,6 @@
 import type { Rule } from '@unocss/core'
 import type { Theme } from '../theme'
-import { handler as h, parseColor } from '../utils'
+import { parseColor } from '../utils'
 import { varEmpty } from './static'
 
 const shadowColorResolver = (body: string, theme: Theme) => {
@@ -9,23 +9,15 @@ const shadowColorResolver = (body: string, theme: Theme) => {
   if (!data)
     return
 
-  const { alpha, opacity, color, rgba } = data
+  const { color, rgba } = data
 
   if (!color)
     return
 
   if (rgba) {
-    if (alpha != null) {
-      return {
-        '--un-shadow-opacity': rgba[3],
-        '--un-shadow-color': rgba.slice(0, 3).join(','),
-      }
-    }
-    else {
-      return {
-        '--un-shadow-opacity': (opacity && h.cssvar(opacity)) ?? 1,
-        '--un-shadow-color': rgba.join(','),
-      }
+    // shadow opacity ignored
+    return {
+      '--un-shadow-color': `${rgba.slice(0, 3).join(',')}`,
     }
   }
   else {
@@ -48,6 +40,5 @@ export const boxShadows: Rule<Theme>[] = [
     }
   }],
   [/^shadow-(.+)$/, ([, d], { theme }) => shadowColorResolver(d, theme)],
-  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent.cssvar(opacity) })],
   ['shadow-inset', { '--un-shadow-inset': 'inset' }],
 ]

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -20,12 +20,12 @@ export const borderRadius = {
 }
 
 export const boxShadow = {
-  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
-  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05))',
-  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 2px 4px -2px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
-  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 4px 6px -4px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
-  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1))',
-  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.25))',
-  'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05))',
+  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1)',
+  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05)',
+  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 2px 4px -2px rgba(var(--un-shadow-color), 0.1)',
+  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 4px 6px -4px rgba(var(--un-shadow-color), 0.1)',
+  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1)',
+  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), 0.25)',
+  'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), 0.05)',
   'none': '0 0 #0000',
 }

--- a/packages/preset-mini/src/theme/misc.ts
+++ b/packages/preset-mini/src/theme/misc.ts
@@ -20,12 +20,12 @@ export const borderRadius = {
 }
 
 export const boxShadow = {
-  'DEFAULT': 'var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1)',
-  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05)',
-  'md': 'var(--un-shadow-inset) 0 4px 6px -1px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 2px 4px -2px rgba(var(--un-shadow-color), 0.1)',
-  'lg': 'var(--un-shadow-inset) 0 10px 15px -3px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 4px 6px -4px rgba(var(--un-shadow-color), 0.1)',
-  'xl': 'var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1)',
-  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(var(--un-shadow-color), 0.25)',
-  'inner': 'inset 0 2px 4px 0 rgba(var(--un-shadow-color), 0.05)',
+  'DEFAULT': ['var(--un-shadow-inset) 0 1px 3px 0 rgba(0,0,0,0.1)', 'var(--un-shadow-inset) 0 1px 2px -1px rgba(0,0,0,0.1)'],
+  'sm': 'var(--un-shadow-inset) 0 1px 2px 0 rgba(0,0,0,0.05)',
+  'md': ['var(--un-shadow-inset) 0 4px 6px -1px rgba(0,0,0,0.1)', 'var(--un-shadow-inset) 0 2px 4px -2px rgba(0,0,0,0.1)'],
+  'lg': ['var(--un-shadow-inset) 0 10px 15px -3px rgba(0,0,0,0.1)', 'var(--un-shadow-inset) 0 4px 6px -4px rgba(0,0,0,0.1)'],
+  'xl': ['var(--un-shadow-inset) 0 20px 25px -5px rgba(0,0,0,0.1)', 'var(--un-shadow-inset) 0 8px 10px -6px rgba(0,0,0,0.1)'],
+  '2xl': 'var(--un-shadow-inset) 0 25px 50px -12px rgba(0,0,0,0.25)',
+  'inner': 'inset 0 2px 4px 0 rgba(0,0,0,0.05)',
   'none': '0 0 #0000',
 }

--- a/packages/preset-mini/src/theme/types.ts
+++ b/packages/preset-mini/src/theme/types.ts
@@ -20,7 +20,7 @@ export interface Theme {
   lineHeight?: Record<string, string>
   letterSpacing?: Record<string, string>
   wordSpacing?: Record<string, string>
-  boxShadow?: Record<string, string>
+  boxShadow?: Record<string, string | string[]>
   textIndent?: Record<string, string>
   textShadow?: Record<string, string | string[]>
   textStrokeWidth?: Record<string, string>

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -8,5 +8,5 @@ exports[`cli > builds uno.css 1`] = `
 
 exports[`cli > supports unocss.config.js 1`] = `
 "/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.05));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
+.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
 `;

--- a/test/__snapshots__/cli.test.ts.snap
+++ b/test/__snapshots__/cli.test.ts.snap
@@ -8,5 +8,6 @@ exports[`cli > builds uno.css 1`] = `
 
 exports[`cli > supports unocss.config.js 1`] = `
 "/* layer: shortcuts */
-.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(var(--un-shadow-color), 0.05);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
+.box{--un-ring-offset-shadow:0 0 #0000;--un-ring-shadow:0 0 #0000;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow:0 0 #0000;--un-shadow-colored:0 0 #0000;}
+.box{margin-left:auto;margin-right:auto;max-width:80rem;border-radius:0.375rem;--un-bg-opacity:1;background-color:rgba(243,244,246,var(--un-bg-opacity));padding:1rem;--un-shadow:var(--un-shadow-inset) 0 1px 2px 0 rgba(0,0,0,0.05);--un-shadow-colored:var(--un-shadow-inset) 0 1px 2px 0 var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}"
 `;

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -272,7 +272,7 @@ exports[`preset-mini > targets 1`] = `
 .shadow-none,
 .shadow-xl{--un-ring-offset-shadow:0 0 #0000;--un-ring-shadow:0 0 #0000;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow:0 0 #0000;--un-shadow-colored:0 0 #0000;}
 .shadow{--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(0,0,0,0.1),var(--un-shadow-inset) 0 1px 2px -1px rgba(0,0,0,0.1);--un-shadow-colored:var(--un-shadow-inset) 0 1px 3px 0 var(--un-shadow-color),var(--un-shadow-inset) 0 1px 2px -1px var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-none{--un-shadow:var(--un-shadow-inset) 0 0 #0000;--un-shadow-colored:var(--un-shadow-inset) 0 0 var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-none{--un-shadow:0 0 #0000;--un-shadow-colored:0 0 var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-xl{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(0,0,0,0.1),var(--un-shadow-inset) 0 8px 10px -6px rgba(0,0,0,0.1);--un-shadow-colored:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-current{--un-shadow-color:currentColor;--un-shadow:var(--un-shadow-colored);}
 .shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:rgba(34,197,94,var(--un-shadow-opacity));--un-shadow:var(--un-shadow-colored);}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -268,15 +268,22 @@ exports[`preset-mini > targets 1`] = `
 .text-opacity-\\\\[13\\\\.3333333\\\\%\\\\]{--un-text-opacity:13.3333333%;}
 .italic{font-style:italic;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:grayscale;}
-.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-none{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:0 0 #0000;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-current{--un-shadow-color:currentColor;}
-.shadow-green-500{--un-shadow-color:34,197,94;}
-.shadow-transparent{--un-shadow-color:transparent;}
+.shadow,
+.shadow-none,
+.shadow-xl{--un-ring-offset-shadow:0 0 #0000;--un-ring-shadow:0 0 #0000;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow:0 0 #0000;--un-shadow-colored:0 0 #0000;}
+.shadow{--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(0,0,0,0.1),var(--un-shadow-inset) 0 1px 2px -1px rgba(0,0,0,0.1);--un-shadow-colored:var(--un-shadow-inset) 0 1px 3px 0 var(--un-shadow-color),var(--un-shadow-inset) 0 1px 2px -1px var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-none{--un-shadow:var(--un-shadow-inset) 0 0 #0000;--un-shadow-colored:var(--un-shadow-inset) 0 0 var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-xl{--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(0,0,0,0.1),var(--un-shadow-inset) 0 8px 10px -6px rgba(0,0,0,0.1);--un-shadow-colored:var(--un-shadow-inset) 0 20px 25px -5px var(--un-shadow-color),var(--un-shadow-inset) 0 8px 10px -6px var(--un-shadow-color);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-current{--un-shadow-color:currentColor;--un-shadow:var(--un-shadow-colored);}
+.shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:rgba(34,197,94,var(--un-shadow-opacity));--un-shadow:var(--un-shadow-colored);}
+.shadow-green-900\\\\/50{--un-shadow-color:rgba(20,83,45,0.5);--un-shadow:var(--un-shadow-colored);}
+.shadow-transparent{--un-shadow-color:transparent;--un-shadow:var(--un-shadow-colored);}
+.shadow-op-50{--un-shadow-opacity:0.5;}
 .shadow-inset{--un-shadow-inset:inset;}
-.ring{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
-.ring-10{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
+.ring,
+.ring-10{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147,197,253,0.5);--un-ring-offset-shadow:0 0 #0000;--un-ring-shadow:0 0 #0000;--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow:0 0 #0000;--un-shadow-colored:0 0 #0000;}
+.ring{--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
+.ring-10{--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
 .ring-offset{--un-ring-offset-width:1px;}
 .ring-offset-4{--un-ring-offset-width:4px;}
 .ring-red2{--un-ring-opacity:1;--un-ring-color:rgba(254,202,202,var(--un-ring-opacity));}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -268,14 +268,12 @@ exports[`preset-mini > targets 1`] = `
 .text-opacity-\\\\[13\\\\.3333333\\\\%\\\\]{--un-text-opacity:13.3333333%;}
 .italic{font-style:italic;}
 .antialiased{-webkit-font-smoothing:antialiased;-moz-osx-font-smoothing:grayscale;font-smoothing:grayscale;}
-.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 1px 3px 0 rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 1px 2px -1px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-none{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:0 0 #0000;box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
-.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1)), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), var(--un-shadow-opacity, 0.1));box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
+.shadow-xl{--un-shadow-inset:var(--un-empty,/*!*/ /*!*/);--un-shadow-color:0,0,0;--un-shadow:var(--un-shadow-inset) 0 20px 25px -5px rgba(var(--un-shadow-color), 0.1), var(--un-shadow-inset) 0 8px 10px -6px rgba(var(--un-shadow-color), 0.1);box-shadow:var(--un-ring-offset-shadow, 0 0 #0000), var(--un-ring-shadow, 0 0 #0000), var(--un-shadow);}
 .shadow-current{--un-shadow-color:currentColor;}
-.shadow-green-500{--un-shadow-opacity:1;--un-shadow-color:34,197,94;}
-.shadow-green-900\\\\/50{--un-shadow-opacity:0.5;--un-shadow-color:20,83,45;}
+.shadow-green-500{--un-shadow-color:34,197,94;}
 .shadow-transparent{--un-shadow-color:transparent;}
-.shadow-op-50{--un-shadow-opacity:0.5;}
 .shadow-inset{--un-shadow-inset:inset;}
 .ring{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(1px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}
 .ring-10{--un-ring-inset:var(--un-empty,/*!*/ /*!*/);--un-ring-offset-width:0px;--un-ring-offset-color:#fff;--un-ring-color:rgba(147, 197, 253, .5);--un-ring-offset-shadow:var(--un-ring-inset) 0 0 0 var(--un-ring-offset-width) var(--un-ring-offset-color);--un-ring-shadow:var(--un-ring-inset) 0 0 0 calc(10px + var(--un-ring-offset-width)) var(--un-ring-color);box-shadow:var(--un-ring-offset-shadow), var(--un-ring-shadow), var(--un-shadow, 0 0 #0000);}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -287,6 +287,8 @@ export const presetMiniTargets: string[] = [
   'shadow-none',
   'shadow-xl',
   'shadow-green-500',
+  'shadow-green-900/50',
+  'shadow-op-50',
   'shadow-inset',
 
   // size

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -287,8 +287,6 @@ export const presetMiniTargets: string[] = [
   'shadow-none',
   'shadow-xl',
   'shadow-green-500',
-  'shadow-green-900/50',
-  'shadow-op-50',
   'shadow-inset',
 
   // size


### PR DESCRIPTION
Since #452 & #453 is using the same logic, I'll retry #450 here.

- The inset shadow css variable that was previously auto-generated are now kept.
- The color value must use **NO** space. Ex:

```css
'sm': '0 1px 2px 0 rgba(0,0,0,0.05)',
'hex': '0 1px 2px 0 #2228',
```
