### PR TITLE
refactor(preset-mini,preset-wind)!: remove cssvar in color opacity modifier

### DIFF
--- a/packages/preset-mini/src/rules/color.ts
+++ b/packages/preset-mini/src/rules/color.ts
@@ -13,7 +13,7 @@ export const opacity: Rule[] = [
  */
 export const textColors: Rule[] = [
   [/^(?:text|color|c)-(.+)$/, colorResolver('color', 'text')],
-  [/^(?:text|color|c)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-opacity': h.bracket.percent.cssvar(opacity) })],
+  [/^(?:text|color|c)-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-text-opacity': h.bracket.percent(opacity) })],
 ]
 
 export const bgColors: Rule[] = [

--- a/packages/preset-mini/src/rules/shadow.ts
+++ b/packages/preset-mini/src/rules/shadow.ts
@@ -40,7 +40,7 @@ export const boxShadows: Rule<Theme>[] = [
 
   // color
   [/^shadow-(.+)$/, colorResolver('--un-shadow-color', 'shadow')],
-  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent.cssvar(opacity) })],
+  [/^shadow-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-shadow-opacity': h.bracket.percent(opacity) })],
 
   // inset
   ['shadow-inset', { '--un-shadow-inset': 'inset' }],

--- a/packages/preset-wind/src/rules/filters.ts
+++ b/packages/preset-wind/src/rules/filters.ts
@@ -101,7 +101,7 @@ export const filters: Rule<Theme>[] = [
   // drop-shadow only on filter
   [/^(?:filter-)?drop-shadow(?:-(.+))?$/, dropShadowResolver],
   [/^(?:filter-)?drop-shadow-color-(.+)$/, colorResolver('--un-drop-shadow-color', 'drop-shadow')],
-  [/^(?:filter-)?drop-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-drop-shadow-opacity': h.bracket.percent.cssvar(opacity) })],
+  [/^(?:filter-)?drop-shadow-color-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-drop-shadow-opacity': h.bracket.percent(opacity) })],
   [/^(?:(backdrop-)|filter-)?grayscale(?:-(.+))?$/, toFilter('grayscale', percentWithDefault)],
   [/^(?:(backdrop-)|filter-)?hue-rotate-(.+)$/, toFilter('hue-rotate', s => h.bracket.degree(s))],
   [/^(?:(backdrop-)|filter-)?invert(?:-(.+))?$/, toFilter('invert', percentWithDefault)],

--- a/packages/preset-wind/src/rules/placeholder.ts
+++ b/packages/preset-wind/src/rules/placeholder.ts
@@ -5,5 +5,5 @@ export const placeholders: Rule[] = [
   // The prefix `$ ` is intentional. This rule is not to be matched directly from user-generated token.
   // See variants/placeholder.
   [/^\$ placeholder-(.+)$/, colorResolver('color', 'placeholder')],
-  [/^\$ placeholder-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-placeholder-opacity': h.bracket.percent.cssvar(opacity) })],
+  [/^\$ placeholder-op(?:acity)?-?(.+)$/, ([, opacity]) => ({ '--un-placeholder-opacity': h.bracket.percent(opacity) })],
 ]

--- a/packages/preset-wind/src/variants/placeholder.ts
+++ b/packages/preset-wind/src/variants/placeholder.ts
@@ -25,6 +25,6 @@ function hasColorValue(body: string, theme: Theme) {
 function hasOpacityValue(body: string) {
   const match = body.match(/^op(?:acity)?-?(.+)$/)
   if (match && match[1] != null)
-    return h.bracket.percent.cssvar(match[1]) != null
+    return h.bracket.percent(match[1]) != null
   return false
 }


### PR DESCRIPTION
This PR removes all `handler.cssvar` in all `x-opacity` rules because any other opacity rules don't have it. Also the `x-opacity` modifier is aleady producing css variable.

The standalone `opacity-x` is not modified and still have `cssvar` support.

Alternatively, we should add `cssvar` to all other rules that don't have it.