### PR TITLE
fix(preset-mini): remove `skew` without direction

### DIFF
--- a/packages/preset-mini/src/rules/transform.ts
+++ b/packages/preset-mini/src/rules/transform.ts
@@ -82,7 +82,6 @@ export const transforms: Rule[] = [
   [/^translate-([xyz])-(.+)$/, handleTranslate],
   [/^rotate-()(.+)$/, handleRotate],
   [/^rotate(-[xyz])-(.+)$/, handleRotate],
-  [/^skew-()(.+)$/, handleSkew],
   [/^skew-([xy])-(.+)$/, handleSkew],
   [/^scale-()(.+)$/, handleScale],
   [/^scale-([xyz])-(.+)$/, handleScale],


### PR DESCRIPTION
Alternatively, assign both skew x & y on `skew-n` without direction.