### PR TITLE
feat(inspector + playground): all scrolls visible + colors

### DIFF
--- a/packages/inspector/client/auto-imports.d.ts
+++ b/packages/inspector/client/auto-imports.d.ts
@@ -95,6 +95,7 @@ declare global {
   const useCounter: typeof import('@vueuse/core')['useCounter']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVar: typeof import('@vueuse/core')['useCssVar']
+  const useCssVars: typeof import('vue')['useCssVars']
   const useCycleList: typeof import('@vueuse/core')['useCycleList']
   const useDark: typeof import('@vueuse/core')['useDark']
   const useDebounce: typeof import('@vueuse/core')['useDebounce']

--- a/packages/inspector/client/components/CodeMirror.vue
+++ b/packages/inspector/client/components/CodeMirror.vue
@@ -102,8 +102,8 @@ onMounted(async() => {
   --cm-regex: #ab5e3f;
   --cm-json-property: #698c96;
   /* scrollbars colors */
-  --uni-ttc-c-thumb: #ddd;
-  --uni-ttc-c-track: white;
+  --cm-ttc-c-thumb: #eee;
+  --cm-ttc-c-track: white;
 }
 
 html.dark {
@@ -132,8 +132,8 @@ html.dark {
   --cm-line-highlight-background: #444444;
   --cm-selection-background: #44444450;
   /* scrollbars colors */
-  --uni-ttc-c-thumb: #666;
-  --uni-ttc-c-track: black;
+  --cm-ttc-c-thumb: #222;
+  --cm-ttc-c-track: #111;
 }
 
 .highlighted {
@@ -149,7 +149,7 @@ html.dark {
   overflow: auto !important;
   height: calc(100vh - 2px) !important;
   scrollbar-width: thin;
-  scrollbar-color: var(--uni-ttc-c-thumb) var(--uni-ttc-c-track);
+  scrollbar-color: var(--cm-ttc-c-thumb) var(--cm-ttc-c-track);
 }
 .scrolls-sidebar {
   height: calc(100vh - 25px - 1.5rem - 65px - 1rem - 2px) !important;
@@ -168,17 +168,17 @@ html.dark {
 }
 .CodeMirror-scroll::-webkit-scrollbar-track,
 .scrolls::-webkit-scrollbar-track {
-  background: var(--uni-ttc-c-track);
+  background: var(--cm-ttc-c-track);
 }
 .CodeMirror-scroll::-webkit-scrollbar-thumb,
 .scrolls::-webkit-scrollbar-thumb {
-  background-color: var(--uni-ttc-c-thumb);
+  background-color: var(--cm-ttc-c-thumb);
   border-radius: 3px;
-  border: 2px solid var(--uni-ttc-c-thumb);
+  border: 2px solid var(--cm-ttc-c-thumb);
 }
 .CodeMirror-scroll::-webkit-scrollbar-corner,
 .scrolls::-webkit-scrollbar-corner {
-  background-color: var(--uni-ttc-c-track);
+  background-color: var(--cm-ttc-c-track);
 }
 .CodeMirror {
   overflow: unset !important;

--- a/packages/inspector/client/components/ModuleTreeNode.vue
+++ b/packages/inspector/client/components/ModuleTreeNode.vue
@@ -29,7 +29,7 @@ const route = useRoute()
       v-for="i of node.items"
       :key="i.full"
       ml4
-      truncate
+      ws-nowrap
     >
       <RouterLink
         block

--- a/packages/inspector/client/main.css
+++ b/packages/inspector/client/main.css
@@ -33,7 +33,8 @@ html:not(.dark) {
 }
 
 .splitpanes--vertical > .splitpanes__splitter:before {
-  left: -10px;
+  /* fix vertical scrollbar */
+  /*left: -10px;*/
   right: -10px;
   height: 100%;
 }

--- a/playground/src/auto-imports.d.ts
+++ b/playground/src/auto-imports.d.ts
@@ -95,6 +95,7 @@ declare global {
   const useCounter: typeof import('@vueuse/core')['useCounter']
   const useCssModule: typeof import('vue')['useCssModule']
   const useCssVar: typeof import('@vueuse/core')['useCssVar']
+  const useCssVars: typeof import('vue')['useCssVars']
   const useCycleList: typeof import('@vueuse/core')['useCycleList']
   const useDark: typeof import('@vueuse/core')['useDark']
   const useDebounce: typeof import('@vueuse/core')['useDebounce']

--- a/playground/src/components/Editor.vue
+++ b/playground/src/components/Editor.vue
@@ -130,6 +130,7 @@ onMounted(() => {
         flex-auto
         mode="htmlmixed"
         border="l gray-400/20"
+        class="scrolls"
         :matched="output?.matched || new Set()"
       />
     </Pane>
@@ -152,6 +153,7 @@ onMounted(() => {
         flex-auto
         mode="css"
         border="l gray-400/20"
+        class="scrolls"
         :read-only="true"
       />
     </Pane>
@@ -165,7 +167,7 @@ onMounted(() => {
           />
         </template>
       </TitleBar>
-      <CodeMirror v-model="customConfigRaw" flex-auto mode="javascript" border="l gray-400/20" />
+      <CodeMirror v-model="customConfigRaw" flex-auto mode="javascript" border="l gray-400/20" class="scrolls" />
       <div
         v-if="customConfigError"
         absolute

--- a/playground/src/main.css
+++ b/playground/src/main.css
@@ -1,7 +1,15 @@
+:root {
+  /* scrollbars colors */
+  --play-ttc-c-thumb: #eee;
+  --play-ttc-c-track: white;
+}
 .dark {
   color-scheme: dark;
   background: #080808;
   color: white;
+  /* scrollbars colors */
+  --play-ttc-c-thumb: #222;
+  --play-ttc-c-track: #111;
 }
 
 .splitpanes__splitter {
@@ -24,13 +32,59 @@
 }
 
 .splitpanes--vertical > .splitpanes__splitter:before {
-  left: -10px;
+  /* fix vertical scrollbar */
+  /*left: -10px;*/
   right: -10px;
   height: 100%;
 }
 
 .splitpanes--horizontal > .splitpanes__splitter:before {
-  top: -10px;
+  /* fix vertical scrollbar */
+  /*top: -10px;*/
   bottom: -10px;
   width: 100%;
 }
+
+.CodeMirror-scroll::-webkit-scrollbar,
+.scrolls::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+.scrolls {
+  overflow: auto !important;
+  width: 100%;
+  height: calc(100% - 34px - 3px) !important;
+  scrollbar-width: thin;
+  scrollbar-color: var(--play-ttc-c-thumb) var(--play-ttc-c-track);
+}
+.CodeMirror-scroll::-webkit-scrollbar-track,
+.scrolls::-webkit-scrollbar-track {
+  background: var(--play-ttc-c-track);
+}
+.CodeMirror-scroll::-webkit-scrollbar-thumb,
+.scrolls::-webkit-scrollbar-thumb {
+  background-color: var(--play-ttc-c-thumb);
+  border-radius: 3px;
+  border: 2px solid var(--play-ttc-c-thumb);
+}
+.CodeMirror-scroll::-webkit-scrollbar-corner,
+.scrolls::-webkit-scrollbar-corner {
+  background-color: var(--play-ttc-c-track);
+}
+.CodeMirror {
+  overflow: unset !important;
+}
+.CodeMirror-vscrollbar,
+.CodeMirror-hscrollbar {
+  display: none !important;
+}
+.CodeMirror-scroll {
+  margin-bottom: unset !important;
+  margin-right: unset !important;
+  padding-bottom: unset !important;
+}
+.scrolls .CodeMirror .CodeMirror-scroll {
+  width: 100%;
+  height: 100%;
+}
+


### PR DESCRIPTION
This PR fixes:
- code mirror scrolls on playground editor visible: right now the horizontal scrolls are on the overflow
- on inspector now the `ModuleTreeNode` will use `ws-nowrap` instead `truncate`: see screenshots bellow opening the inspector when running the playground
- scrolls colors and bottom right corner background color on inspector and playground
- vertical split panes divider will now have left 0 and horizontal ones top 0 to allow use the scroll with mouse: on inspector and on playgorund

closes #493 

Inspector using `ws-nowrap`: 

![imagen](https://user-images.githubusercontent.com/6311119/149662185-dd40cafe-13fc-460e-aab2-54b5bcd7553c.png)

Inspector using `truncate` (since the text is truncated then the width of the div will be the container one and so the horizontal scroll will disappear):

![imagen](https://user-images.githubusercontent.com/6311119/149662262-f500eee4-45a3-4fae-847e-ca6fa3477cef.png)

