### PR TITLE
fix(preset-mini,preset-wind): escape css custom properties

### DIFF
--- a/packages/preset-mini/src/rules/variables.ts
+++ b/packages/preset-mini/src/rules/variables.ts
@@ -19,10 +19,10 @@ const variablesAbbrMap: Record<string, string> = {
 }
 
 export const cssVariables: Rule[] = [
-  [/^(.+?)-\$(.+)$/, ([, name, varname]) => {
+  [/^(.+?)-(\$.+)$/, ([, name, varname]) => {
     const prop = variablesAbbrMap[name]
     if (prop)
-      return { [prop]: `var(--${varname})` }
+      return { [prop]: h.cssvar(varname) }
   }],
 ]
 

--- a/packages/preset-mini/src/utils/handlers/handlers.ts
+++ b/packages/preset-mini/src/utils/handlers/handlers.ts
@@ -1,3 +1,5 @@
+import { escapeSelector } from '@unocss/core'
+
 // Not all, but covers most high frequency attributes
 const cssProps = [
   // basic props
@@ -103,7 +105,7 @@ export function bracket(str: string) {
 
 export function cssvar(str: string) {
   if (str.startsWith('$'))
-    return `var(--${str.slice(1)})`
+    return `var(--${escapeSelector(str.slice(1))})`
 }
 
 export function time(str: string) {

--- a/packages/preset-mini/src/utils/handlers/handlers.ts
+++ b/packages/preset-mini/src/utils/handlers/handlers.ts
@@ -104,7 +104,7 @@ export function bracket(str: string) {
 }
 
 export function cssvar(str: string) {
-  if (str.startsWith('$'))
+  if (str.match(/^\$\S/))
     return `var(--${escapeSelector(str.slice(1))})`
 }
 

--- a/packages/preset-wind/src/rules/variables.ts
+++ b/packages/preset-wind/src/rules/variables.ts
@@ -1,4 +1,5 @@
 import type { Rule } from '@unocss/core'
+import { handler as h } from '@unocss/preset-mini/utils'
 
 const variablesAbbrMap: Record<string, string> = {
   'bg-blend': 'background-blend-mode',
@@ -17,9 +18,9 @@ const variablesAbbrMap: Record<string, string> = {
 }
 
 export const cssVariables: Rule[] = [
-  [/^(.+?)-\$(.+)$/, ([, name, varname]) => {
+  [/^(.+?)-(\$.+)$/, ([, name, varname]) => {
     const prop = variablesAbbrMap[name]
     if (prop)
-      return { [prop]: `var(--${varname})` }
+      return { [prop]: h.cssvar(varname) }
   }],
 ]

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -13,6 +13,7 @@ exports[`preset-mini > targets 1`] = `
 .flex-\\\\$variable{flex:var(--variable);}
 .fw-\\\\$variable{font-weight:var(--variable);}
 .items-\\\\$size{align-items:var(--size);}
+.ws-\\\\$\\\\{row\\\\.span\\\\}\\\\/24{white-space:var(--\\\\{row\\\\.span\\\\}\\\\/24);}
 .ws-\\\\$variable{white-space:var(--variable);}
 .\\\\[a\\\\:b\\\\]{a:b;}
 .\\\\[background-image\\\\:url\\\\(star_transparent\\\\.gif\\\\)\\\\2c _url\\\\(cat_front\\\\.png\\\\)\\\\]{background-image:url(star\\\\_transparent.gif), url(cat\\\\_front.png);}

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -392,7 +392,7 @@ exports[`preset-mini > targets 1`] = `
 .auto-flow-col-dense{grid-auto-flow:column dense;}
 .grid-cols-\\\\[1fr_2fr_100px_min-content\\\\]{grid-template-columns:1fr 2fr 100px min-content;}
 .grid-cols-\\\\[repeat\\\\(3\\\\2c auto\\\\)\\\\]{grid-template-columns:repeat(3,auto);}
-.grid-cols-\\\\$1{grid-template-columns:var(--1);}
+.grid-cols-\\\\$1{grid-template-columns:var(--\\\\31 );}
 .grid-rows-\\\\[1fr_2fr_100px_min-content\\\\]{grid-template-rows:1fr 2fr 100px min-content;}
 .grid-cols-minmax-1rem{grid-template-columns:repeat(auto-fill,minmax(1rem,1fr));}
 .grid-rows-minmax-100px{grid-template-rows:repeat(auto-fill,minmax(100px,1fr));}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -635,6 +635,10 @@ export const presetMiniTargets: string[] = [
   'word-spacing-$variable',
   'ws-$variable',
 
+  // variables - escaping
+  // eslint-disable-next-line no-template-curly-in-string
+  'ws-${row.span}/24',
+
   // variables - property
   '[a:b]',
   '[margin:logical_1rem_2rem_3rem]',

--- a/test/preset-uno.test.ts
+++ b/test/preset-uno.test.ts
@@ -63,6 +63,10 @@ const nonTargets = [
   // mini - typography
   'tab-',
 
+  // mini - variable
+  'tab-$',
+  'ws-$',
+
   // wind - placeholder
   '$-placeholder-red-200',
 ]


### PR DESCRIPTION
Addresses #534. Since this is unavoidable with the built-in extractor, escape the variable name instead.