### PR TITLE
feat(runtime): fire a callback when the runtime is ready

### DIFF
--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -75,7 +75,7 @@ export interface RuntimeContext {
 declare global {
   interface Window {
     __unocss?: UserConfig & { runtime?: RuntimeOptions }
-    __unocss_runtime?: RuntimeObject
+    __unocss_runtime?: RuntimeContext
   }
 }
 

--- a/packages/runtime/src/index.ts
+++ b/packages/runtime/src/index.ts
@@ -19,12 +19,12 @@ export interface RuntimeOptions {
   /**
    * Callback when the runtime is ready. Returning false will prevent default extraction
    */
-  ready?: (runtime: RuntimeObject) => false | any
+  ready?: (runtime: RuntimeContext) => false | any
 }
 
 export type RuntimeInspectorCallback = (element: Element) => boolean
 
-export interface RuntimeObject {
+export interface RuntimeContext {
   /**
    * The UnoCSS instance.
    *


### PR DESCRIPTION
Two uses:
- to make the default extraction (`extractAll`) preventable
- to be able to config the runtime from one place. ex:

```js
window.__unocss = { runtime: {
    ready({ extract }) {
        fetch(...)
            .then(r => r.text)
            .then(t => extract(t))
```

instead of 

```html
<script src="./uno.global.js"></script>
<script>
const { extract } = window.__unocss_runtime;
fetch(...)
    .then(r => r.text)
    .then(t => extract(t))
</script>