### PR TITLE
feat(preset-mini): use cssvar for `display-*` utilities

### DIFF
--- a/packages/preset-mini/src/rules/static.ts
+++ b/packages/preset-mini/src/rules/static.ts
@@ -12,6 +12,7 @@ export const displays: Rule[] = [
   ['flow-root', { display: 'flow-root' }],
   ['list-item', { display: 'list-item' }],
   ['hidden', { display: 'none' }],
+  [/^display-(.+)$/, ([, c]) => ({ display: h.bracket.cssvar(c) || c })],
 ]
 
 export const appearances: Rule[] = [


### PR DESCRIPTION
Besides this being handy, it allows `presetAttributify` users to work around `<div hidden>` colliding with https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/hidden