### PR TITLE
feat(preset-wind): sass mix color variant

### DIFF
--- a/packages/preset-wind/src/index.ts
+++ b/packages/preset-wind/src/index.ts
@@ -4,7 +4,7 @@ import { variants as miniVariants } from '@unocss/preset-mini/variants'
 import { rules } from './rules'
 import { containerShortcuts } from './rules/container'
 import { theme } from './theme'
-import { placeholderModifier, variantColorsScheme, variantSpaceAndDivide } from './variants'
+import { placeholderModifier, variantColorMix, variantColorsScheme, variantSpaceAndDivide } from './variants'
 
 export { colors } from '@unocss/preset-mini'
 
@@ -28,6 +28,7 @@ export const presetWind = (options: UnoOptions = {}): Preset<Theme> => {
     variants: [
       placeholderModifier,
       variantSpaceAndDivide,
+      variantColorMix,
       ...miniVariants(options),
       ...variantColorsScheme,
     ],

--- a/packages/preset-wind/src/variants/index.ts
+++ b/packages/preset-wind/src/variants/index.ts
@@ -1,4 +1,5 @@
 /* @export-submodules */
 export * from './dark'
 export * from './misc'
+export * from './mix'
 export * from './placeholder'

--- a/packages/preset-wind/src/variants/mix.ts
+++ b/packages/preset-wind/src/variants/mix.ts
@@ -1,0 +1,54 @@
+import type { CSSColorValue, Variant } from '@unocss/core'
+import { parseCssColor } from '@unocss/preset-mini/utils'
+
+const mixComponent = (v1: string | number, v2: string | number, w: string | number) => `calc(${v2} + (${v1} - ${v2}) * ${w} / 100)`
+
+const mixColor = (color1: string | CSSColorValue, color2: string | CSSColorValue, weight: string | number): CSSColorValue | undefined => {
+  const colors = [color1, color2]
+  const cssColors: CSSColorValue[] = []
+  for (let c = 0; c < 2; ++c) {
+    const color = (typeof colors[c] === 'string' ? parseCssColor(colors[c] as string) : colors[c]) as CSSColorValue | undefined
+    if (!color || !['rgb', 'rgba'].includes(color.type))
+      return
+    cssColors.push(color)
+  }
+
+  const newComponents = []
+  for (let x = 0; x < 3; ++x)
+    newComponents.push(mixComponent(cssColors[0].components[x], cssColors[1].components[x], weight))
+
+  return {
+    type: 'rgb',
+    components: newComponents,
+    alpha: mixComponent(cssColors[0].alpha ?? 1, cssColors[1].alpha ?? 1, weight),
+  }
+}
+
+const tint = (color: string | CSSColorValue, weight: string | number) => mixColor('#fff', color, weight)
+const shade = (color: string | CSSColorValue, weight: string | number) => mixColor('#000', color, weight)
+const shift = (color: string | CSSColorValue, weight: string | number) => parseInt(`${weight}`, 10) > 0 ? shade(color, weight) : tint(color, `-${weight}`)
+const fns: Record<string, (color: string | CSSColorValue, weight: string | number) => CSSColorValue | undefined> = { tint, shade, shift }
+
+export const variantColorMix: Variant = (matcher) => {
+  const m = matcher.match(/^mix-(tint|shade|shift)-(-?\d{1,3})[-:]/)
+  if (m) {
+    return {
+      matcher: matcher.slice(m[0].length),
+      body: (body) => {
+        body.forEach((v) => {
+          if (v[1]) {
+            const color = parseCssColor(`${v[1]}`)
+            if (color) {
+              const mixed = fns[m[1]](color, m[2])
+              if (mixed) {
+                const { alpha, components } = mixed
+                v[1] = `rgb(${components.join(',')},${alpha})`
+              }
+            }
+          }
+        })
+        return body
+      },
+    }
+  }
+}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -250,6 +250,10 @@ exports[`preset-wind > targets 1`] = `
 .lining-nums{--un-numeric-figure:lining-nums;font-variant-numeric:var(--un-font-variant-numeric);}
 .tabular-nums{--un-numeric-spacing:tabular-nums;font-variant-numeric:var(--un-font-variant-numeric);}
 .normal-nums{font-variant-numeric:normal;}
+.mix-shade-50-c-red-400{--un-text-opacity:1;color:rgb(calc(248 + (0 - 248) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(113 + (0 - 113) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
+.mix-shift--50-c-red-600{--un-text-opacity:1;color:rgb(calc(220 + (255 - 220) * --50 / 100),calc(38 + (255 - 38) * --50 / 100),calc(38 + (255 - 38) * --50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * --50 / 100));}
+.mix-shift-50-c-red-600{--un-text-opacity:1;color:rgb(calc(220 + (0 - 220) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(38 + (0 - 38) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
+.mix-tint-50-c-red-400{--un-text-opacity:1;color:rgb(calc(248 + (255 - 248) * 50 / 100),calc(113 + (255 - 113) * 50 / 100),calc(113 + (255 - 113) * 50 / 100),calc(var(--un-text-opacity) + (1 - var(--un-text-opacity)) * 50 / 100));}
 .hyphens-auto{-webkit-hyphens:auto;-ms-hyphens:auto;hyphens:auto;}
 .hyphens-none{-webkit-hyphens:none;-ms-hyphens:none;hyphens:none;}
 .write-normal{writing-mode:horizontal-tb;}

--- a/test/preset-wind-targets.ts
+++ b/test/preset-wind-targets.ts
@@ -315,6 +315,12 @@ export const presetWindiTargets: string[] = [
   '.dark:text-xl',
   '@dark:text-xl',
 
+  // variants - mix
+  'mix-tint-50-c-red-400',
+  'mix-shade-50-c-red-400',
+  'mix-shift-50-c-red-600',
+  'mix-shift--50-c-red-600',
+
   // variants - placeholder
   'placeholder-red-400',
   'placeholder-inherit',


### PR DESCRIPTION
This PR adds sass' mix function, especially mixing with white/black.

see https://sass-lang.com/documentation/modules/color#mix

Usually useful for hover/active color so you can use single base color for control state:

[Playground](https://deploy-preview-570--ecstatic-mestorf-2e8afd.netlify.app/?html=DwEwlgbgBAxgNgQwM5ILwCIBGBzAtAdwAswAXAUykNyRgCcyyA7KAMzjIA9X2PcYB7OFFJkAtkj5NytKACsArkhJgWAT0mNpUbAgAOuAGzoAfACgowTPJIl%2BzeMjTp9ARgAsUchxLVCCEPz4uHDYULT88owgZCDBoUh%2BAfjmUKlp6alePgn%2BgXyC-LS4qmRwcHkAnAAMVSkZ9Ti4mHDyZIY1dfXpJnWEpeUpwAD0VjZ2ZhajtvaIKBiuHlm%2BuUEhYRFRMXFQOUmdXZmc2Yl5AuVFJWWVHQcZjc2t7bW36YT8EGS0AFyiYLy7bQArF97i02gYbi9UggYMoPj8-storgAExVL4AQlBjwhzyhUB6aT6V0GI2s0wmlnJdlgsycC08RyReTW4Ui0Via12gX2ByW3KCZ0KxX61zxUN%2B-0SQJBeAe4MhUMJqWJA1Swym41Mw3AEGMQA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmcAvnOlBCHAOQCuWEAxgM6u0BQnqAHpLBQYAhvQA28NJhz5CwIgAoEnOHCjjUrAFxwA2itV7azeqxjUAtOrGpaAGkRxmEMdB20oqZLTIBdA-6kAJRAA&options=N4IgzgLgTglgxhEAuaBXApgXyA)

Inspired from
https://getbootstrap.com/docs/5.0/customize/color/#notes-on-sass
https://github.com/twbs/bootstrap/blob/612d235faf3515dacceb19df04f1d32b9ef62c55/scss/_functions.scss#L205-L218
https://codepen.io/emdeoh/pen/zYOQOPB

Also to compare with the codepen, since this implementation uses css' `calc` instead of parsing with js:
[Playground](https://deploy-preview-570--ecstatic-mestorf-2e8afd.netlify.app/?html=DwEwlgbgBAxgNgQwM5ILwCIBGBzAtAdwAswAXAUykNyRgCcyyA7KAMzjIA8pSyBbJXDCblaUAFYBXJCTAsAnoOFlR2BAAdcARnQA%2BAFBRDUYJgkkSAe2bxkaLBdohlUTA6e1cmRDADWUDZoADFC0FhKMTiC4cNhQvGAc1IQITlqBgZ54AMSBLCy6wAD0puZW%2BkbGJZbWiCgYro7ODe6e3n4BwaHhkdGx8YlIyakAHBk4uDl5BcVm1eVGJrNWsLV2zU1uyq0Ivv5pIWERZFExcQlJKWS4AGxj2bn5OkVVZQYLLzW29Zui6x5eO3a%2By6RxOfXOg0uuAALHcJg9ph95oZFqVPnV7I1fj9trsOgdusdemcBkMrgAmOGTR7PJaMZGVOkrL6Y9wuHEAvHAw49U7jamIukM1HVZkYv7srG4oFBAmg4n9XAyRgkXCUzLwqZPGZo4UfMVrH6SlqcmWdHlE06K5Wq2EagXapFvFH6mzio1-aV7WUg3ngxI2m5UhGOoXOxlog3fLHGram73mwlgklKsAq3Cje0h2m68Mi5Zuw0xz3x-G%2By3%2B1PpoLBrU5uZ6IrgCA6IA&config=JYWwDg9gTgLgBAbzgEwKYDNgDtUGEJaYDmcAvnOlBCHAOQCuWEAxgM6u0BQnqAHpLBQYAhvQA28NJhz5CwIgAoEnOHCjjUrAFxwA2itV7azeqxjUAtOrGpaAGkRxmEMdB20oqZLTIBdA-6kAJRAA&options=N4IgzgLgTglgxhEAuaBXApgXyA)