### PR TITLE
feat(core): add option to override layer from variant

### DIFF
--- a/packages/core/src/generator/index.ts
+++ b/packages/core/src/generator/index.ts
@@ -290,6 +290,7 @@ export class UnoGenerator {
       selector: handlers.reduce((p, v) => v.selector?.(p, entries) || p, toEscapedSelector(raw)),
       entries,
       parent: handlers.reduce((p: string | undefined, v) => Array.isArray(v.parent) ? v.parent[0] : v.parent || p, undefined),
+      layer: handlers.reduce((p: string | undefined, v) => v.layer || p, undefined),
     }
 
     for (const p of this.config.postprocess)
@@ -360,13 +361,14 @@ export class UnoGenerator {
     if (isRawUtil(parsed))
       return [parsed[0], undefined, parsed[1], undefined, parsed[2]]
 
-    const { selector, entries, parent } = this.applyVariants(parsed)
+    const { selector, entries, parent, layer: variantLayer } = this.applyVariants(parsed)
     const body = entriesToCss(entries)
 
     if (!body)
       return
 
-    return [parsed[0], selector, body, parent, parsed[3]]
+    const { layer: metaLayer, ...meta } = parsed[3] ?? {}
+    return [parsed[0], selector, body, parent, { ...meta, layer: variantLayer ?? metaLayer }]
   }
 
   expandShortcut(processed: string, context: RuleContext, depth = 3): [string[], RuleMeta | undefined] | undefined {

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -168,6 +168,10 @@ export interface VariantHandler {
    * Variant ordering.
    */
   order?: number
+  /**
+   * Override layer to the output css.
+   */
+  layer?: string | undefined
 }
 
 export type VariantFunction<Theme extends {} = {}> = (matcher: string, context: Readonly<VariantContext<Theme>>) => string | VariantHandler | undefined
@@ -397,6 +401,7 @@ export interface UtilObject {
   selector: string
   entries: CSSEntries
   parent: string | undefined
+  layer: string | undefined
 }
 
 export interface GenerateOptions {

--- a/packages/preset-mini/src/variants/default.ts
+++ b/packages/preset-mini/src/variants/default.ts
@@ -5,11 +5,12 @@ import { variantBreakpoints } from './breakpoints'
 import { variantCombinators } from './combinators'
 import { variantColorsMediaOrClass } from './dark'
 import { variantLanguageDirections } from './directions'
-import { variantImportant, variantNegative } from './misc'
+import { variantImportant, variantLayer, variantNegative } from './misc'
 import { variantMotions, variantOrientations, variantPrint } from './media'
 import { partClasses, variantPseudoClassFunctions, variantPseudoClasses, variantPseudoElements, variantTaggedPseudoClasses } from './pseudo'
 
 export const variants = (options: PresetMiniOptions): Variant<Theme>[] => [
+  variantLayer,
   variantNegative,
   variantImportant,
   variantPrint,

--- a/packages/preset-mini/src/variants/misc.ts
+++ b/packages/preset-mini/src/variants/misc.ts
@@ -1,5 +1,17 @@
 import type { Variant } from '@unocss/core'
 
+export const variantLayer: Variant = {
+  match(matcher) {
+    const match = matcher.match(/layer-([\d\w]+)[:-]/)
+    if (match) {
+      return {
+        matcher: matcher.slice(match[0].length),
+        layer: match[1],
+      }
+    }
+  },
+}
+
 export const variantImportant: Variant = {
   match(matcher) {
     if (matcher.startsWith('!')) {

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -9,7 +9,10 @@ exports[`preset-mini > custom var prefix 1`] = `
 `;
 
 exports[`preset-mini > targets 1`] = `
-"/* layer: default */
+"/* layer: 1 */
+.layer-1\\\\:translate-0{--un-rotate:0;--un-rotate-x:0;--un-rotate-y:0;--un-rotate-z:0;--un-scale-x:1;--un-scale-y:1;--un-scale-z:1;--un-skew-x:0;--un-skew-y:0;--un-translate-x:0;--un-translate-y:0;--un-translate-z:0;--un-transform:translateX(var(--un-translate-x)) translateY(var(--un-translate-y)) translateZ(var(--un-translate-z)) rotate(var(--un-rotate)) rotateX(var(--un-rotate-x)) rotateY(var(--un-rotate-y)) rotateZ(var(--un-rotate-z)) skewX(var(--un-skew-x)) skewY(var(--un-skew-y)) scaleX(var(--un-scale-x)) scaleY(var(--un-scale-y)) scaleZ(var(--un-scale-z));}
+.layer-1\\\\:translate-0{--un-translate-x:0rem;--un-translate-y:0rem;transform:var(--un-transform);}
+/* layer: default */
 .flex-\\\\$variable{flex:var(--variable);}
 .fw-\\\\$variable{font-weight:var(--variable);}
 .items-\\\\$size{align-items:var(--size);}
@@ -747,5 +750,7 @@ exports[`preset-mini > targets 1`] = `
 }
 @media (min-width: 1536px){
 .at-2xl\\\\:m2{margin:0.5rem;}
-}"
+}
+/* layer: unocss */
+.layer-unocss\\\\:block{display:block;}"
 `;

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -697,6 +697,10 @@ export const presetMiniTargets: string[] = [
   // variants combinators
   'svg:fill-red',
 
+  // variants layer
+  'layer-1:translate-0',
+  'layer-unocss:block',
+
   // variants motion
   'motion-reduce:hover:translate-0',
   'motion-safe:transition',


### PR DESCRIPTION
Just like parent, this allows layer to be applied by variant.

With this we can simplify the `x-none` rules integrating it to its parent thus reducing rule count.