### PR TITLE
feat(preset-mini): add parent-x as group-x with direct descendant

### DIFF
--- a/packages/preset-mini/src/variants/pseudo.ts
+++ b/packages/preset-mini/src/variants/pseudo.ts
@@ -147,6 +147,10 @@ export const variantTaggedPseudoClasses = (options: PresetMiniOptions = {}): Var
       match: taggedPseudoClassMatcher('peer', attributify ? '[peer=""]' : '.peer', '~'),
       multiPass: true,
     },
+    {
+      match: taggedPseudoClassMatcher('parent', attributify ? '[parent=""]' : '.parent', '>'),
+      multiPass: true,
+    },
   ]
 }
 

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -249,7 +249,8 @@ exports[`preset-mini > targets 1`] = `
 .text-shadow-color-op-30{--un-text-shadow-opacity:0.3;}
 .case-upper{text-transform:uppercase;}
 .case-normal{text-transform:none;}
-.group:focus:hover .group-hover\\\\:group-focus\\\\:text-center{text-align:center;}
+.group:focus:hover .group-hover\\\\:group-focus\\\\:text-center,
+.parent:hover>.parent-hover\\\\:text-center{text-align:center;}
 .text-left,
 [dir=\\"ltr\\"] .ltr\\\\:text-left{text-align:left;}
 [dir=\\"rtl\\"] .rtl\\\\:text-right{text-align:right;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -678,7 +678,6 @@ export const presetMiniTargets: string[] = [
   'children:m-auto',
   'disabled:op50',
   'first:p-2',
-  'group-focus:p-4',
   'group-hover:group-focus:text-center',
   'hover:!p-1',
   'hover:not-first:checked:bg-red/10',
@@ -689,7 +688,6 @@ export const presetMiniTargets: string[] = [
   'md:m-1',
   'next:mt-0',
   'not-hover:p-3',
-  'peer-checked:bg-blue-500',
   'peer-not-placeholder-shown:text-2xl',
   'sm:m-1',
   'sm:m1',
@@ -741,4 +739,9 @@ export const presetMiniTargets: string[] = [
   'focus-within:where-first:checked:bg-gray/20',
   'group-has-placeholder-shown:text-4xl',
   'focus-within:has-first:checked:bg-gray/20',
+
+  // variants - tagged
+  'group-focus:p-4',
+  'peer-checked:bg-blue-500',
+  'parent-hover:text-center',
 ]


### PR DESCRIPTION
Use case for this is for parent-hover to nested tables' row.

See rationale here https://github.com/tailwindlabs/tailwindcss/pull/271