### PR TITLE
refactor(preset-mini,preset-wind): merge rules

### DIFF
--- a/packages/preset-mini/src/rules/position.ts
+++ b/packages/preset-mini/src/rules/position.ts
@@ -118,8 +118,7 @@ export const floats: Rule[] = [
 ]
 
 export const zIndexes: Rule[] = [
-  [/^z-(.+)$/, ([, v]) => ({ 'z-index': h.bracket.cssvar.number(v) })],
-  ['z-auto', { 'z-index': 'auto' }],
+  [/^z-(.+)$/, ([, v]) => ({ 'z-index': h.bracket.cssvar.auto.number(v) })],
 ]
 
 export const boxSizing: Rule[] = [

--- a/packages/preset-mini/src/rules/transition.ts
+++ b/packages/preset-mini/src/rules/transition.ts
@@ -5,6 +5,7 @@ import { handler as h } from '../utils'
 const transitionPropertyGroup: Record<string, string> = {
   all: 'all',
   colors: ['color', 'background-color', 'border-color', 'text-decoration-color', 'fill', 'stroke'].join(','),
+  none: 'none',
   opacity: 'opacity',
   shadow: 'box-shadow',
   transform: 'transform',
@@ -37,8 +38,6 @@ export const transitions: Rule<Theme>[] = [
   // props
   [/^(?:transition-)?property-(.+)$/, ([, v]) => ({ 'transition-property': h.global(v) || transitionProperty(v) })],
 
-  // nones
-  ['transition-property-none', { 'transition-property': 'none' }],
-  ['property-none', { 'transition-property': 'none' }],
+  // none
   ['transition-none', { transition: 'none' }],
 ]

--- a/packages/preset-wind/src/rules/animation.ts
+++ b/packages/preset-wind/src/rules/animation.ts
@@ -28,12 +28,10 @@ export const animations: Rule<Theme>[] = [
   [/^animate-ease(?:-(.+))?$/, ([, d], { theme }) => ({ 'animation-timing-function': theme.easing?.[d || 'DEFAULT'] ?? h.bracket.cssvar(d) })],
 
   // fill mode
-  [/^animate-(?:fill-|mode-|fill-mode-)?(forwards|backwards|both|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-fill-mode': d })],
-  [/^animate-(?:fill-|mode-|fill-mode-)none$/, () => ({ 'animation-fill-mode': 'none' })],
+  [/^animate-(?:fill-|mode-|fill-mode-)?(none|forwards|backwards|both|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-fill-mode': d })],
 
   // direction
-  [/^animate-(?:direction-)?(reverse|alternate|alternate-reverse|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-direction': d })],
-  [/^animate-(?:direction-)?normal$/, () => ({ 'animation-direction': 'normal' })],
+  [/^animate-(?:direction-)?(normal|reverse|alternate|alternate-reverse|inherit|initial|revert|unset)$/, ([, d]) => ({ 'animation-direction': d })],
 
   // others
   [/^animate-(?:iteration-|count-|iteration-count-)(.+)$/, ([, d]) => ({ 'animation-iteration-count': h.bracket.cssvar(d) ?? d.replace(/\-/g, ',') })],

--- a/packages/preset-wind/src/rules/filters.ts
+++ b/packages/preset-wind/src/rules/filters.ts
@@ -44,8 +44,8 @@ const percentWithDefault = (str?: string) => {
 
 const toFilter = (varName: string, resolver: (str: string, theme: Theme) => string | undefined) =>
   ([, b, s]: string[], { theme }: RuleContext<Theme>): CSSValues | undefined => {
-    const value = resolver(s, theme)
-    if (value != null && value !== '') {
+    const value = resolver(s, theme) ?? (s === 'none' ? '0' : '')
+    if (value !== '') {
       if (b) {
         return [
           backdropFilterBase,
@@ -129,9 +129,4 @@ export const filters: Rule<Theme>[] = [
     '-webkit-backdrop-filter': 'none',
     'backdrop-filter': 'none',
   }],
-  [/^(?:filter-)?(blur|brightness|contrast|drop-shadow|grayscale|hue-rotate|invert|saturate|sepia)-none$/, ([, s]) => ({ filter: `${s}(0)` })],
-  [/^backdrop-(blur|brightness|contrast|grayscale|hue-rotate|invert|opacity|saturate|sepia)-none$/, ([, s]) => ({
-    '-webkit-backdrop-filter': `${s}(0)`,
-    'backdrop-filter': `${s}(0)`,
-  })],
 ]

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -600,10 +600,10 @@ exports[`preset-mini > targets 1`] = `
 .property-all,
 .transition-property-all{transition-property:all;}
 .property-margin\\\\2c padding{transition-property:margin,padding;}
+.property-none{transition-property:none;}
 .property-padding\\\\2c margin{transition-property:padding,margin;}
 .property-unset{transition-property:unset;}
 .transition-property-width{transition-property:width;}
-.property-none{transition-property:none;}
 .transition-none{transition:none;}
 .origin-top-left{transform-origin:top left;}
 .perspect-\\\\$variable{-webkit-perspective:var(--variable);perspective:var(--variable);}

--- a/test/__snapshots__/preset-wind.test.ts.snap
+++ b/test/__snapshots__/preset-wind.test.ts.snap
@@ -89,8 +89,8 @@ exports[`preset-wind > targets 1`] = `
 .animate-fill-mode-both{animation-fill-mode:both;}
 .animate-mode-none{animation-fill-mode:none;}
 .animate-direction-alternate-reverse{animation-direction:alternate-reverse;}
-.animate-reverse{animation-direction:reverse;}
 .animate-normal{animation-direction:normal;}
+.animate-reverse{animation-direction:reverse;}
 .animate-count-2\\\\.4{animation-iteration-count:2.4;}
 .animate-iteration-2{animation-iteration-count:2;}
 .animate-iteration-count-\\\\[2\\\\2c 4\\\\2c infinity\\\\]{animation-iteration-count:count,[2,4,infinity];}
@@ -267,6 +267,7 @@ exports[`preset-wind > targets 1`] = `
 .backdrop-blur,
 .backdrop-blur-4,
 .backdrop-blur-md,
+.backdrop-blur-none,
 .backdrop-brightness-0,
 .backdrop-brightness-60,
 .backdrop-contrast-125,
@@ -287,13 +288,16 @@ exports[`preset-wind > targets 1`] = `
 .backdrop-blur{--un-backdrop-blur:blur(8px);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .backdrop-blur-4{--un-backdrop-blur:blur(4px);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .backdrop-blur-md{--un-backdrop-blur:blur(12px);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
+.backdrop-blur-none{--un-backdrop-blur:blur(0);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .blur,
 .blur-\\\\$variable,
 .blur-4,
 .blur-md,
+.blur-none,
 .filter-blur,
 .filter-blur-4,
 .filter-blur-md,
+.filter-blur-none,
 .brightness-\\\\$variable,
 .brightness-0,
 .brightness-60,
@@ -302,6 +306,7 @@ exports[`preset-wind > targets 1`] = `
 .drop-shadow,
 .drop-shadow-\\\\[0_4px_3px_\\\\#000\\\\],
 .drop-shadow-\\\\$variable,
+.drop-shadow-none,
 .drop-shadow-sm,
 .grayscale,
 .grayscale-\\\\$variable,
@@ -328,6 +333,8 @@ exports[`preset-wind > targets 1`] = `
 .filter-blur-4{--un-blur:blur(4px);filter:var(--un-filter);}
 .blur-md,
 .filter-blur-md{--un-blur:blur(12px);filter:var(--un-filter);}
+.blur-none,
+.filter-blur-none{--un-blur:blur(0);filter:var(--un-filter);}
 .backdrop-brightness-0{--un-backdrop-brightness:brightness(0);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .backdrop-brightness-60{--un-backdrop-brightness:brightness(0.6);-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .brightness-\\\\$variable{--un-brightness:brightness(var(--variable));filter:var(--un-filter);}
@@ -339,6 +346,7 @@ exports[`preset-wind > targets 1`] = `
 .drop-shadow{--un-drop-shadow:drop-shadow(0 1px 2px var(--un-drop-shadow-color, rgba(0,0,0,0.1))) drop-shadow(0 1px 1px var(--un-drop-shadow-color, rgba(0,0,0,0.06)));filter:var(--un-filter);}
 .drop-shadow-\\\\[0_4px_3px_\\\\#000\\\\]{--un-drop-shadow:drop-shadow(0 4px 3px #000);filter:var(--un-filter);}
 .drop-shadow-\\\\$variable{--un-drop-shadow:drop-shadow(var(--variable));filter:var(--un-filter);}
+.drop-shadow-none{--un-drop-shadow:drop-shadow(0 0 var(--un-drop-shadow-color, #0000));filter:var(--un-filter);}
 .drop-shadow-sm{--un-drop-shadow:drop-shadow(0 1px 1px var(--un-drop-shadow-color, rgba(0,0,0,0.05)));filter:var(--un-filter);}
 .drop-shadow-color-red-300{--un-drop-shadow-opacity:1;--un-drop-shadow-color:rgba(252,165,165,var(--un-drop-shadow-opacity));}
 .drop-shadow-color-op-30{--un-drop-shadow-opacity:0.3;}
@@ -376,10 +384,6 @@ exports[`preset-wind > targets 1`] = `
 .backdrop-filter{-webkit-backdrop-filter:var(--un-backdrop-filter);backdrop-filter:var(--un-backdrop-filter);}
 .filter-none{filter:none;}
 .backdrop-filter-none{-webkit-backdrop-filter:none;backdrop-filter:none;}
-.blur-none,
-.filter-blur-none{filter:blur(0);}
-.drop-shadow-none{filter:drop-shadow(0);}
-.backdrop-blur-none{-webkit-backdrop-filter:blur(0);backdrop-filter:blur(0);}
 .placeholder-inherit::placeholder{color:inherit;}
 .placeholder-red-400::placeholder{--un-placeholder-opacity:1;color:rgba(248,113,113,var(--un-placeholder-opacity));}
 @media (prefers-color-scheme: dark){


### PR DESCRIPTION
With addition of layer variant (#571), some of the workaround to prioritize rule order can be removed.

preset-mini:
- merge `z-auto`
- merge `transition-property-none` & `property-none`

preset-wind:
- merge `animate-fill-mode-none` (`animate-none` will still hold the precedence due to rule order)
- merge `animate-direction-normal`
- merge `filter-x-none` & `backdrop-x-none`