### PR TITLE
refactor(preset-mini): merge decoration rules

### DIFF
--- a/packages/preset-mini/src/rules/decoration.ts
+++ b/packages/preset-mini/src/rules/decoration.ts
@@ -2,11 +2,7 @@ import type { CSSObject, Rule } from '@unocss/core'
 import { colorResolver, handler as h } from '../utils'
 
 export const textDecorations: Rule[] = [
-  ['underline', { 'text-decoration-line': 'underline' }],
-  ['overline', { 'text-decoration-line': 'overline' }],
-  ['line-through', { 'text-decoration-line': 'line-through' }],
-  ['decoration-underline', { 'text-decoration-line': 'underline' }],
-  ['decoration-line-through', { 'text-decoration-line': 'line-through' }],
+  [/^(?:decoration-)?(underline|overline|line-through)$/, ([, s]) => ({ 'text-decoration-line': s })],
 
   // size
   [/^(?:underline|decoration)-(?:size-)?(.+)$/, ([, s]) => ({ 'text-decoration-thickness': h.bracket.cssvar.px(s) })],

--- a/test/__snapshots__/preset-mini.test.ts.snap
+++ b/test/__snapshots__/preset-mini.test.ts.snap
@@ -225,6 +225,7 @@ exports[`preset-mini > targets 1`] = `
 .indent-1\\\\/2{text-indent:50%;}
 .indent-lg{text-indent:2rem;}
 .text-clip{text-overflow:clip;}
+.decoration-underline,
 .underline{text-decoration-line:underline;}
 .decoration-5,
 .underline-5{text-decoration-thickness:5px;}

--- a/test/preset-mini-targets.ts
+++ b/test/preset-mini-targets.ts
@@ -185,6 +185,7 @@ export const presetMiniTargets: string[] = [
   'decoration-purple/50',
   'decoration-5',
   'decoration-offset-0.6rem',
+  'decoration-underline',
   'underline',
   'underline-dashed',
   'underline-red-500',


### PR DESCRIPTION
Alternatively, add this static rule:
```ts
['decoration-overline', { 'text-decoration-line': 'overline' }],
```